### PR TITLE
Major ERAM DCB UI enhancement including brightness controls and tearoff features

### DIFF
--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -188,6 +188,8 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 .ac-db.emrg { color: #ff4444; }
 .dwell-border { position: absolute; pointer-events: none; border: 1px solid #cccc44; }
 .emrg .dwell-border { border-color: #ff4444; }
+/* Portal fence: top-left corner bracket on FDB lines 1-4 */
+/* Portal fence is rendered as an inline SVG — no CSS border needed */
 .ac-db.ldb.dwell { outline: 1px solid #cccc44; outline-offset: 1px; }
 .ac-db.ldb.dwell.emrg { outline-color: #ff4444; }
 /* .ac-db.ho — handoff flash now driven by JS */

--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -486,6 +486,13 @@ body.tb-active #sidebar-wrapper { top: 70px; }
     color: #6666aa; font-size: 6px; line-height: 6px;
 }
 
+/* Momentary toggle indicator triangle (top right) */
+.tb-btn .tb-momentary-ind {
+    position: absolute; top: 1px; right: 1px;
+    font-size: 7px; line-height: 1; font-weight: bold;
+    pointer-events: none;
+}
+
 /* ── Special button backgrounds ── */
 /* Black background (RANGE, ALT LIM) */
 .tb-btn.tb-dark { background: #000; }

--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -5,12 +5,12 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 /* ── Layout ── */
 #app { position: relative; height: 100vh; }
 #sidebar-wrapper { display: flex; position: absolute; top: 0; left: 0; bottom: 0; z-index: 500; }
-#sidebar { width: 260px; min-width: 260px; background: #111; border-right: 1px solid #333; display: flex; flex-direction: column; overflow-y: auto; overflow-x: hidden; transition: margin-left 0.2s ease; scrollbar-width: thin; scrollbar-color: #333 #1a1a1a; }
+#sidebar { width: 290px; min-width: 290px; background: #111; border-right: 1px solid #333; display: flex; flex-direction: column; overflow-y: auto; overflow-x: hidden; transition: margin-left 0.2s ease; scrollbar-width: thin; scrollbar-color: #333 #1a1a1a; cursor: default; }
 #sidebar::-webkit-scrollbar { width: 6px; }
 #sidebar::-webkit-scrollbar-track { background: #1a1a1a; }
 #sidebar::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
 #sidebar::-webkit-scrollbar-thumb:hover { background: #444; }
-#sidebar.collapsed { margin-left: -260px; }
+#sidebar.collapsed { margin-left: -290px; }
 #sidebar-toggle {
     width: 20px; background: #1a1a1a; border: none; border-right: 1px solid #333;
     color: #666; cursor: pointer; display: flex; align-items: center; justify-content: center;
@@ -44,23 +44,95 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
     letter-spacing: 1px;
 }
 .sidebar-home-link:hover { background: #333; border-color: #cccc44; }
+#btn-fullscreen {
+    background: #222 !important;
+    color: #cccc44 !important;
+    border: 1px solid #444 !important;
+    transition: background-color 0.1s ease, border-color 0.1s ease;
+}
+#btn-fullscreen:hover {
+    background: #333 !important;
+    border-color: #cccc44 !important;
+}
 
 .panel-section { padding: 10px 12px; border-bottom: 1px solid #222; }
-.panel-label { font-size: 10px; color: #666; letter-spacing: 1.5px; margin-bottom: 8px; font-weight: bold; }
+.panel-label { font-size: 10px; color: #666; letter-spacing: 1.5px; margin-bottom: 8px; font-weight: bold; cursor: default; }
 
-.ctrl-row { display: flex; align-items: center; margin-bottom: 6px; font-size: 11px; }
-.ctrl-row label { color: #aaa; min-width: 60px; cursor: pointer; display: flex; align-items: center; gap: 6px; }
+.ctrl-row { display: flex; align-items: center; margin-bottom: 6px; font-size: 11px; gap: 12px; }
+.ctrl-row label { color: #aaa; min-width: 60px; cursor: default; display: flex; align-items: center; gap: 6px; }
 .ctrl-row select {
     flex: 1; background: #1a1a1a; color: #cccc44; border: 1px solid #333;
-    padding: 3px 6px; font-family: inherit; font-size: 11px; outline: none;
+    padding: 2px 4px; font-family: inherit; font-size: 11px; outline: none;
     scrollbar-width: thin; scrollbar-color: #333 #1a1a1a;
+    cursor: pointer;
 }
 .ctrl-row select::-webkit-scrollbar { width: 6px; }
 .ctrl-row select::-webkit-scrollbar-track { background: #1a1a1a; }
 .ctrl-row select::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
 .ctrl-row select::-webkit-scrollbar-thumb:hover { background: #444; }
+.ctrl-row select:hover {
+    background: #333;
+    border-color: #cccc44;
+}
 .ctrl-row select:focus { border-color: #cccc44; }
-.ctrl-row input[type="checkbox"] { accent-color: #cccc44; }
+.ctrl-row input[type="number"] {
+    flex: 1 !important;
+    background: #1a1a1a !important;
+    color: #cccc44 !important;
+    border: 1px solid #333 !important;
+    padding: 2px 4px !important;
+    font-family: inherit !important;
+    font-size: 11px !important;
+    outline: none !important;
+    cursor: text;
+}
+.ctrl-row input[type="number"]::-webkit-outer-spin-button,
+.ctrl-row input[type="number"]::-webkit-inner-spin-button {
+    background: #1a1a1a !important;
+    opacity: 1;
+}
+.ctrl-row input[type="number"]::-webkit-outer-spin-button {
+    filter: invert(0.8);
+}
+.ctrl-row input[type="number"]::-webkit-inner-spin-button {
+    filter: invert(0.8);
+}
+.ctrl-row input[type="number"]:hover {
+    background: #333 !important;
+    border-color: #cccc44 !important;
+}
+.ctrl-row input[type="number"]:focus { border-color: #cccc44 !important; }
+.ctrl-row input[type="range"] { flex: 1; cursor: pointer; }
+input[type="checkbox"] {
+    accent-color: #cccc44;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    width: 13px;
+    height: 13px;
+    background: #333;
+    border: 1px solid #555;
+    border-radius: 2px;
+    cursor: pointer;
+    position: relative;
+    vertical-align: -2px;
+    flex-shrink: 0;
+}
+input[type="checkbox"]:checked {
+    background: #cccc44;
+    border-color: #cccc44;
+}
+input[type="checkbox"]:checked::after {
+    content: '✓';
+    position: absolute;
+    color: #000;
+    font-size: 12px;
+    font-weight: bold;
+    left: 0px;
+    top: -3px;
+    width: 100%;
+    text-align: center;
+}
 
 #sector-checkboxes {
     max-height: 200px; overflow-y: auto; font-size: 11px; color: #aaa;
@@ -70,6 +142,17 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 #sector-checkboxes::-webkit-scrollbar-track { background: #1a1a1a; }
 #sector-checkboxes::-webkit-scrollbar-thumb { background: #444; border-radius: 3px; }
 #sector-checkboxes::-webkit-scrollbar-thumb:hover { background: #666; }
+#sector-checkboxes label {
+    cursor: default;
+    padding: 2px 4px;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    transition: border-color 0.1s ease;
+}
+#sector-checkboxes label:hover {
+    border-color: #cccc44;
+}
+#sector-checkboxes input[type="checkbox"] { cursor: pointer; margin-left: 4px; }
 
 .traffic-row { font-size: 12px; padding: 2px 0; display: flex; justify-content: space-between; }
 .traffic-row.own { color: #cccc44; }
@@ -83,16 +166,26 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 }
 #cmd-help-btn {
     background: #222; border: 1px solid #444; color: #888; font-family: inherit;
-    font-size: 10px; padding: 2px 8px; cursor: pointer; margin-top: 6px;
+    font-size: 10px; padding: 2px 8px; cursor: pointer; margin-top: 6px; white-space: nowrap;
 }
 #cmd-help-btn:hover { border-color: #cccc44; color: #cccc44; }
+#replay-toggle-btn {
+    background: #222; border: 1px solid #444; color: #888; font-family: inherit;
+    font-size: 10px; padding: 2px 8px; cursor: pointer; margin-left: 4px; white-space: nowrap;
+}
+#replay-toggle-btn:hover { border-color: #cccc44; color: #cccc44; }
 #cmd-help-popup {
     display: none; position: fixed; z-index: 10000;
     top: 50%; left: 50%; transform: translate(-50%, -50%);
     background: #1a1a1a; border: 1px solid #cccc44; padding: 16px 20px;
     font-family: 'ERAM', 'Consolas', monospace; font-size: 11px;
     color: #ccc; max-width: 600px; max-height: 80vh; overflow-y: auto; line-height: 1.6;
+    scrollbar-width: thin; scrollbar-color: #333 #1a1a1a;
 }
+#cmd-help-popup::-webkit-scrollbar { width: 6px; }
+#cmd-help-popup::-webkit-scrollbar-track { background: #1a1a1a; }
+#cmd-help-popup::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
+#cmd-help-popup::-webkit-scrollbar-thumb:hover { background: #444; }
 #cmd-help-popup h3 { color: #cccc44; margin: 0 0 10px 0; font-size: 13px; }
 #cmd-help-popup h4 { color: #cccc44; margin: 12px 0 4px 0; font-size: 11px; }
 #cmd-help-popup .cmd { color: #cccc44; }

--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -377,7 +377,7 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 }
 #tb-tearoff-btn:hover { background: #007800; }
 #tb-tearoff-btn .tb-gold-strip {
-    width: 13px; background: #b8a040; flex-shrink: 0; cursor: move;
+    width: 13px; background: #FFFFA1; flex-shrink: 0; cursor: move;
 }
 #tb-tearoff-btn .tb-tearoff-label {
     color: #ffffff; white-space: nowrap;
@@ -409,19 +409,21 @@ body.tb-active #sidebar-wrapper { top: 70px; }
     display: flex; flex-direction: row; align-items: stretch;
     width: 88px; height: 34px;
     border: 1px solid #333;
+    border-right: 1px solid #555;
     cursor: pointer;
     position: relative;
     white-space: nowrap;
-    background: #000088;
+    background: #0000D4;
     flex-shrink: 0;
     overflow: hidden;
 }
-.tb-btn:hover { background: #0000aa; }
-.tb-btn:active { background: #0000cc; }
+.tb-btn:hover { background: #0000D4; }
+.tb-btn:active { background: #0000D4; }
 
-/* Tearoff strip on each button — light grey */
+/* Tearoff strip on each button — light grey with border */
 .tb-btn .tb-tear {
-    width: 13px; background: #b8a040; flex-shrink: 0;
+    width: 13px; background: #FFFFA1; flex-shrink: 0;
+    border-right: 1px solid #555;
 }
 
 /* Button content area (label + value) */
@@ -451,15 +453,23 @@ body.tb-active #sidebar-wrapper { top: 70px; }
 /* ── Special button backgrounds ── */
 /* Black background (RANGE, ALT LIM) */
 .tb-btn.tb-dark { background: #000; }
-.tb-btn.tb-dark:hover { background: #111; }
+.tb-btn.tb-dark:hover { background: #000; }
 
-/* Green background (VECTOR) */
-.tb-btn.tb-green { background: #006800; }
-.tb-btn.tb-green:hover { background: #007800; }
+/* Green background (brightness controls) */
+.tb-btn.tb-green { background: #00CD00; }
+.tb-btn.tb-green:hover { background: #00CD00; }
+
+/* Blue background (MAP BRIGHT, CPDLC) */
+.tb-btn.tb-blue { background: #0000D4; }
+.tb-btn.tb-blue:hover { background: #0000D4; }
+
+/* Tan background (menu returns/leave submenus) */
+.tb-btn.tb-tan { background: #DCA09B; }
+.tb-btn.tb-tan:hover { background: #DCA09B; }
 
 /* Teal background (DELETE TEAROFF) */
-.tb-btn.tb-teal { background: #006868; }
-.tb-btn.tb-teal:hover { background: #007878; }
+.tb-btn.tb-teal { background: #00C7D1; }
+.tb-btn.tb-teal:hover { background: #00C7D1; }
 
 /* ── Button type states ── */
 /* Not simulated — dimmer blue */
@@ -469,12 +479,18 @@ body.tb-active #sidebar-wrapper { top: 70px; }
 .tb-btn.tb-nosim .tb-label { color: #8888aa; }
 
 /* Toggle ON — same blue, slightly brighter */
-.tb-btn.tb-toggle-on { background: #0000aa; }
-.tb-btn.tb-toggle-on:hover { background: #0000cc; }
+.tb-btn.tb-toggle-on { background: #0000D4; }
+.tb-btn.tb-toggle-on:hover { background: #0000D4; }
+
+/* Toggle grey (DEST, TYPE, PORTAL FENCE) — off: black, on: light grey */
+.tb-btn.tb-toggle-grey { background: #000000; }
+.tb-btn.tb-toggle-grey:hover { background: #000000; }
+.tb-btn.tb-toggle-grey.tb-toggle-on { background: #C7C7C7; }
+.tb-btn.tb-toggle-grey.tb-toggle-on:hover { background: #C7C7C7; }
 
 /* Menu OPEN — pink/clay */
-.tb-btn.tb-menu-open { background: #884466; }
-.tb-btn.tb-menu-open:hover { background: #994477; }
+.tb-btn.tb-menu-open { background: #DCA09B; }
+.tb-btn.tb-menu-open:hover { background: #DCA09B; }
 
 /* Sub-menu panel — overlays on top of master grid, positioned absolutely */
 .tb-submenu {

--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -483,6 +483,9 @@ body.tb-active #sidebar-wrapper { top: 70px; }
     white-space: nowrap;
     z-index: 2;
 }
+.tb-submenu::-webkit-scrollbar { height: 0px; }
+.tb-submenu::-webkit-scrollbar-thumb { background: #777; border-radius: 2px; }
+.tb-submenu::-webkit-scrollbar-track { background: #222; }
 
 /* Left/right grey bars flanking the button grid */
 .tb-side-bar {

--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -453,6 +453,7 @@ body.tb-active #sidebar-wrapper { top: 70px; }
 }
 /* Disabled tearoff (grey when active tearoff exists) — color set dynamically in JavaScript */
 .tb-btn .tb-tear.tb-tear-disabled {
+    background: #C7C7C7 !important;
     cursor: default !important;
 }
 

--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -93,15 +93,36 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 }
 #cmd-help-popup .close-btn:hover { color: #cccc44; }
 
+/* ── Custom crosshair cursor ── */
+:root {
+    --eram-cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Cline x1='16' y1='9' x2='16' y2='12' stroke='white' stroke-width='4.5'/%3E%3Cline x1='16' y1='20' x2='16' y2='23' stroke='white' stroke-width='4.5'/%3E%3Cline x1='9' y1='16' x2='12' y2='16' stroke='white' stroke-width='4.5'/%3E%3Cline x1='20' y1='16' x2='23' y2='16' stroke='white' stroke-width='4.5'/%3E%3Crect x='12' y='12' width='8' height='8' fill='none' stroke='white' stroke-width='1.3'/%3E%3C/svg%3E") 16 16, crosshair;
+}
+
 /* ── Map overrides ── */
 .leaflet-container {
     background: #000000 !important;
-    cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Cline x1='16' y1='9' x2='16' y2='12' stroke='white' stroke-width='4.5'/%3E%3Cline x1='16' y1='20' x2='16' y2='23' stroke='white' stroke-width='4.5'/%3E%3Cline x1='9' y1='16' x2='12' y2='16' stroke='white' stroke-width='4.5'/%3E%3Cline x1='20' y1='16' x2='23' y2='16' stroke='white' stroke-width='4.5'/%3E%3Crect x='12' y='12' width='8' height='8' fill='none' stroke='white' stroke-width='1.3'/%3E%3C/svg%3E") 16 16, crosshair !important;
+    cursor: var(--eram-cursor) !important;
 }
 .leaflet-control-zoom a { background: #222 !important; color: #cccc44 !important; border-color: #444 !important; }
 .leaflet-control-attribution { display: none !important; }
 /* Boundary/overlay lines: lighten blend so brighter line always shows through overlaps */
 .bnd-path { mix-blend-mode: lighten; }
+
+/* Apply crosshair cursor to interactive elements */
+.ac-db,
+.ac-sym-corr-bcn,
+.ac-sym-reduced-sep,
+.ac-sym-uncorr-bcn,
+.ac-sym-uncorr-pri,
+.ac-sym-flat-track,
+.ac-sym-coast,
+.tb-btn,
+.tb-btn .tb-content,
+.tb-side-bar .tb-arrow-btn,
+#po-menu,
+.field-menu {
+    cursor: var(--eram-cursor) !important;
+}
 
 /* ── Aircraft target group ── */
 .ac-group { position: absolute; pointer-events: none; }
@@ -417,19 +438,30 @@ body.tb-active #sidebar-wrapper { top: 70px; }
     flex-shrink: 0;
     overflow: hidden;
 }
-.tb-btn:hover { background: #0000D4; }
 .tb-btn:active { background: #0000D4; }
 
-/* Tearoff strip on each button — light grey with border */
+/* Tearoff strip on each button — separate button with borders */
 .tb-btn .tb-tear {
     width: 13px; background: #FFFFA1; flex-shrink: 0;
+    border: 1px solid #333;
     border-right: 1px solid #555;
+    cursor: var(--eram-cursor) !important;
+    transition: border-color 0.1s ease;
+}
+.tb-btn .tb-tear:hover {
+    border-color: #ffffff !important;
 }
 
-/* Button content area (label + value) */
+/* Button content area (label + value) with hover border effect */
 .tb-btn .tb-content {
     display: flex; flex-direction: column; align-items: center; justify-content: center;
     flex: 1; padding: 2px 6px; position: relative;
+    border: 1px solid #333;
+    border-right: 1px solid #555;
+    transition: border-color 0.1s ease;
+}
+.tb-btn:has(.tb-content:hover) .tb-content {
+    border-color: #ffffff !important;
 }
 
 /* Label text — white on blue */
@@ -515,8 +547,12 @@ body.tb-active #sidebar-wrapper { top: 70px; }
     width: 14px; height: 34px; background: #555; border: 1px solid #ccc;
     display: flex; align-items: flex-end; justify-content: center;
     cursor: pointer; padding: 0 0 3px 0;
+    transition: border-color 0.1s ease;
 }
-.tb-side-bar .tb-arrow-btn:hover { background: #666; }
+.tb-side-bar .tb-arrow-btn:hover {
+    background: #666;
+    border-color: #ffffff !important;
+}
 .tb-side-bar .tb-arrow-btn svg { width: 8px; height: 14px; }
 /* Master toolbar layout: [left bar] [button grid] [right bar fills to edge] */
 .tb-master-row {

--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -451,6 +451,10 @@ body.tb-active #sidebar-wrapper { top: 70px; }
 .tb-btn .tb-tear:hover {
     border-color: #ffffff !important;
 }
+/* Disabled tearoff (grey when active tearoff exists) — color set dynamically in JavaScript */
+.tb-btn .tb-tear.tb-tear-disabled {
+    cursor: default !important;
+}
 
 /* Button content area (label + value) with hover border effect */
 .tb-btn .tb-content {
@@ -536,6 +540,39 @@ body.tb-active #sidebar-wrapper { top: 70px; }
 .tb-submenu::-webkit-scrollbar { height: 0px; }
 .tb-submenu::-webkit-scrollbar-thumb { background: #777; border-radius: 2px; }
 .tb-submenu::-webkit-scrollbar-track { background: #222; }
+
+/* Floating tearoff — detached button (draggable by tearoff strip) */
+.tb-floating-tearoff {
+    display: flex;
+    position: relative;
+}
+
+/* Tearoff marked for deletion */
+.tb-floating-tearoff .tb-btn.tb-delete-selected {
+    position: relative;
+    opacity: 0.7;
+}
+
+.tb-floating-tearoff .tb-btn.tb-delete-selected::after {
+    content: '✕';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 24px;
+    color: #ff4444;
+    font-weight: bold;
+}
+
+/* Floating menu — popup menu from floating button */
+.tb-floating-menu {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    background: #0000D4 !important;
+    border: 1px solid #FFFFFF !important;
+    white-space: nowrap;
+}
 
 /* Left/right grey bars flanking the button grid */
 .tb-side-bar {

--- a/tools/SwimServer/wwwroot/eram/eram.css
+++ b/tools/SwimServer/wwwroot/eram/eram.css
@@ -5,7 +5,11 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 /* ── Layout ── */
 #app { position: relative; height: 100vh; }
 #sidebar-wrapper { display: flex; position: absolute; top: 0; left: 0; bottom: 0; z-index: 500; }
-#sidebar { width: 260px; min-width: 260px; background: #111; border-right: 1px solid #333; display: flex; flex-direction: column; overflow-y: auto; overflow-x: hidden; transition: margin-left 0.2s ease; }
+#sidebar { width: 260px; min-width: 260px; background: #111; border-right: 1px solid #333; display: flex; flex-direction: column; overflow-y: auto; overflow-x: hidden; transition: margin-left 0.2s ease; scrollbar-width: thin; scrollbar-color: #333 #1a1a1a; }
+#sidebar::-webkit-scrollbar { width: 6px; }
+#sidebar::-webkit-scrollbar-track { background: #1a1a1a; }
+#sidebar::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
+#sidebar::-webkit-scrollbar-thumb:hover { background: #444; }
 #sidebar.collapsed { margin-left: -260px; }
 #sidebar-toggle {
     width: 20px; background: #1a1a1a; border: none; border-right: 1px solid #333;
@@ -49,7 +53,12 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 .ctrl-row select {
     flex: 1; background: #1a1a1a; color: #cccc44; border: 1px solid #333;
     padding: 3px 6px; font-family: inherit; font-size: 11px; outline: none;
+    scrollbar-width: thin; scrollbar-color: #333 #1a1a1a;
 }
+.ctrl-row select::-webkit-scrollbar { width: 6px; }
+.ctrl-row select::-webkit-scrollbar-track { background: #1a1a1a; }
+.ctrl-row select::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
+.ctrl-row select::-webkit-scrollbar-thumb:hover { background: #444; }
 .ctrl-row select:focus { border-color: #cccc44; }
 .ctrl-row input[type="checkbox"] { accent-color: #cccc44; }
 
@@ -392,17 +401,28 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
 #tb-tearoff-btn {
     display: flex; align-items: stretch;
     width: 88px; height: 34px;
-    background: #006800; border: 1px solid #333;
-    cursor: pointer; font-family: 'ERAM', 'Consolas', monospace;
+    background: #00CD00;
+    cursor: var(--eram-cursor) !important; font-family: 'ERAM', 'Consolas', monospace;
     font-size: 10px; line-height: 14px; padding: 0;
 }
-#tb-tearoff-btn:hover { background: #007800; }
 #tb-tearoff-btn .tb-gold-strip {
     width: 13px; background: #FFFFA1; flex-shrink: 0; cursor: move;
+    border: 1px solid #333;
+    border-right: 1px solid #555;
+    transition: border-color 0.1s ease;
+}
+#tb-tearoff-btn .tb-gold-strip:hover {
+    border-color: #ffffff !important;
 }
 #tb-tearoff-btn .tb-tearoff-label {
     color: #ffffff; white-space: nowrap;
     display: flex; align-items: center; justify-content: center; flex: 1;
+    border: 1px solid #333;
+    border-right: 1px solid #555;
+    transition: border-color 0.1s ease;
+}
+#tb-tearoff-btn .tb-tearoff-label:hover {
+    border-color: #ffffff !important;
 }
 
 #master-toolbar-container {
@@ -410,6 +430,7 @@ body { background: #000000; color: #cccc44; font-family: 'ERAM', 'Consolas', 'Co
     top: 0; left: 0; right: 0;
     user-select: none;
     display: none;
+    cursor: var(--eram-cursor) !important;
 }
 #master-toolbar-container.tb-visible { display: block; }
 /* When toolbar is visible, push sidebar below it */

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -784,7 +784,7 @@ function setupNasrSlider(sliderId, labelId, layerKey, url, renderer) {
         nasrBrightness[layerKey] = parseInt(this.value);
         document.getElementById(labelId).textContent = nasrBrightness[layerKey];
         showNasrLayer(layerKey, url, renderer);
-        saveSettingsToUrl();
+        saveSettingsToLocalStorage();
     });
 }
 setupNasrSlider('rng-jroutes', 'lbl-jroutes', 'jroutes', '/api/nasr/airways?type=hi', renderAirways);
@@ -802,7 +802,7 @@ document.getElementById('rng-airports').addEventListener('input', async function
         } catch (e) { console.warn('[NASR] airports:', e); }
     }
     drawOverlay();
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('rng-centerlines').addEventListener('input', async function () {
@@ -815,7 +815,7 @@ document.getElementById('rng-centerlines').addEventListener('input', async funct
         } catch (e) { console.warn('[NASR] centerlines:', e); }
     }
     drawOverlay();
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 // Procedure overlay — managed via .SID/.STAR/.PROC MCA commands
@@ -845,7 +845,7 @@ document.getElementById('rng-proc').addEventListener('input', function () {
             entry.layer.eachLayer(l => l.setStyle({ color: col }));
         }
     }
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 function clearProcOverlay() {
@@ -977,14 +977,14 @@ document.getElementById('sel-nxlvl').addEventListener('change', function () {
     const v = this.value;
     nexradLevel = v === '123' ? 3 : v === '23' ? 2 : v === '3' ? 1 : 0;
     updateNexrad();
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('rng-nx').addEventListener('input', function () {
     nexradBrightness = parseInt(this.value);
     document.getElementById('lbl-nx').textContent = nexradBrightness;
     if (nexradLayer) nexradLayer.setOpacity(nexradBrightness / 100);
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -2130,7 +2130,7 @@ function rebuildSectorCheckboxes() {
                 demoteSectorFlights(this.value);
             }
             invalidateAllMarkers(); // immediately update R indicators and FDB/LDB
-            saveSettingsToUrl();
+            saveSettingsToLocalStorage();
         });
     });
 }
@@ -2654,13 +2654,13 @@ document.getElementById('sel-facility').addEventListener('change', function () {
     rebuildSectorCheckboxes();
     showBoundariesForFacility(myFacility);
     zoomToFacility(myFacility);
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('chk-facility-only').addEventListener('change', function () {
     facilityOnly = this.checked;
     invalidateAllMarkers();
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('sel-histcount').addEventListener('change', function () {
@@ -2669,25 +2669,25 @@ document.getElementById('sel-histcount').addEventListener('change', function () 
         while (hist.length > MAX_HISTORY) hist.shift();
     }
     invalidateAllMarkers();
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('rng-ldb-brightness').addEventListener('input', function () {
     ldbBrightness = parseInt(this.value);
     document.getElementById('lbl-ldb-brightness').textContent = ldbBrightness;
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('sel-vector').addEventListener('change', function () {
     vectorMinutes = parseInt(this.value);
     invalidateAllMarkers();
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('sel-line4').addEventListener('change', function () {
     line4Mode = this.value;
     invalidateAllMarkers();
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 for (const [cat, id] of Object.entries(BOUNDARY_CAT_SLIDER)) {
@@ -2699,7 +2699,7 @@ for (const [cat, id] of Object.entries(BOUNDARY_CAT_SLIDER)) {
     document.getElementById(id).addEventListener('change', function () {
         setBoundaryBrightness(cat, parseInt(this.value));
         document.getElementById(lblId).textContent = this.value;
-        saveSettingsToUrl();
+        saveSettingsToLocalStorage();
     });
 }
 
@@ -2707,18 +2707,18 @@ document.getElementById('chk-mapbg').addEventListener('change', function () {
     showMapBg = this.checked;
     if (showMapBg) tileLayer.addTo(map);
     else map.removeLayer(tileLayer);
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('chk-mca-kb').addEventListener('change', function () {
     document.getElementById('mca').classList.toggle('show-kb', this.checked);
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 // Transp MCA: reserved for future use
 // document.getElementById('chk-transp-mca').addEventListener('change', function () {
 //     document.getElementById('map-container').classList.toggle('transp-mca', this.checked);
-//     saveSettingsToUrl();
+//     saveSettingsToLocalStorage();
 // });
 
 document.getElementById('btn-fullscreen').addEventListener('click', function () {
@@ -2732,17 +2732,17 @@ document.getElementById('btn-fullscreen').addEventListener('click', function () 
 document.getElementById('sel-fontsize').addEventListener('change', function () {
     fontSize = parseInt(this.value);
     updateFontSize();
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('inp-alt-low').addEventListener('change', function () {
     altFilterLow = parseInt(this.value) || 0;
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 document.getElementById('inp-alt-high').addEventListener('change', function () {
     altFilterHigh = parseInt(this.value) || 999;
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 });
 
 function updateScopeBackground() {
@@ -3454,62 +3454,42 @@ setInterval(() => { if (selectedGufi) showFlightDetail(selectedGufi); }, 5000);
 // ════════════════════════════════════════════════════════════════════════════
 // URL-based settings persistence
 // ════════════════════════════════════════════════════════════════════════════
-function loadSettingsFromUrl() {
-    const params = new URLSearchParams(window.location.hash.slice(1));
-    myFacility = params.get('facility') || '';
-    const sectors = params.get('sectors');
-    mySectors = sectors ? new Set(sectors.split(',').filter(s => s)) : new Set();
-    if (params.has('fdb')) showFdb = params.get('fdb') !== '0';
-    if (params.has('history')) showHistory = params.get('history') !== '0';
-    if (params.has('histcount')) MAX_HISTORY = parseInt(params.get('histcount')) || 5;
-    if (params.has('vector')) vectorMinutes = parseInt(params.get('vector'));
-    if (params.has('bndbr')) {
-        const vals = params.get('bndbr').split(',').map(Number);
-        BOUNDARY_CATS.forEach((cat, i) => { if (!isNaN(vals[i])) boundaryBrightness[cat] = vals[i]; });
-    }
-    if (params.has('fontsize')) fontSize = parseInt(params.get('fontsize')) || 10;
-    if (params.has('altlow')) altFilterLow = parseInt(params.get('altlow')) || 0;
-    if (params.has('althigh')) altFilterHigh = parseInt(params.get('althigh')) || 999;
-    if (params.has('ldb')) ldbBrightness = parseInt(params.get('ldb'));
-    if (params.has('faconly')) facilityOnly = params.get('faconly') === '1';
-    if (params.has('mapbg')) showMapBg = params.get('mapbg') === '1';
-    if (params.has('kb')) {
-        document.getElementById('chk-mca-kb').checked = true;
-        document.getElementById('mca').classList.add('show-kb');
-    }
-    if (params.has('numinv')) {
-        document.getElementById('numpad-inverted').checked = false;
-    }
-    // Transp MCA: reserved for future use
-    // if (params.has('tmca')) {
-    //     document.getElementById('map-container').classList.toggle('transp-mca', true);
-    //     document.getElementById('chk-transp-mca').checked = true;
-    // }
-    if (params.has('nasrbr')) {
-        const vals = params.get('nasrbr').split(',').map(Number);
-        if (!isNaN(vals[0])) nasrBrightness.jroutes = vals[0];
-        if (!isNaN(vals[1])) nasrBrightness.vroutes = vals[1];
-        if (!isNaN(vals[2])) nasrBrightness.vors = vals[2];
-        if (!isNaN(vals[3])) nasrBrightness.airports = vals[3];
-        if (!isNaN(vals[4])) nasrBrightness.centerlines = vals[4];
-        if (!isNaN(vals[5])) nasrBrightness.proc = vals[5];
-    }
-    if (params.has('line4')) line4Mode = params.get('line4') || 'DEST';
-    if (params.has('nxlvl')) {
-        const v = params.get('nxlvl');
-        nexradLevel = v === '123' ? 3 : v === '23' ? 2 : v === '3' ? 1 : 0;
-    }
-    if (params.has('nxbr')) nexradBrightness = parseInt(params.get('nxbr'));
-    if (params.has('bckgrd')) scopeBckgrd = Math.max(0, Math.min(100, parseInt(params.get('bckgrd')) || 100));
-    if (params.has('bcklght')) scopeBcklght = Math.max(0, Math.min(100, parseInt(params.get('bcklght')) || 100));
-    if (params.get('tb') === '0') window._tbVisible = false;
+function loadSettingsFromLocalStorage() {
+    try {
+        const saved = localStorage.getItem('eram-settings');
+        if (!saved) return; // Use defaults if no saved settings
 
-    // Restore map position/zoom
-    if (params.has('lat') && params.has('lng') && params.has('z')) {
-        const lat = parseFloat(params.get('lat'));
-        const lng = parseFloat(params.get('lng'));
-        const z = parseInt(params.get('z'));
-        if (!isNaN(lat) && !isNaN(lng) && !isNaN(z)) map.setView([lat, lng], z);
+        const settings = JSON.parse(saved);
+
+        myFacility = settings.facility || '';
+        mySectors = new Set(settings.sectors || []);
+        if (settings.showFdb !== undefined) showFdb = settings.showFdb;
+        if (settings.showHistory !== undefined) showHistory = settings.showHistory;
+        if (settings.MAX_HISTORY !== undefined) MAX_HISTORY = settings.MAX_HISTORY;
+        if (settings.vectorMinutes !== undefined) vectorMinutes = settings.vectorMinutes;
+        if (settings.boundaryBrightness) Object.assign(boundaryBrightness, settings.boundaryBrightness);
+        if (settings.line4Mode) line4Mode = settings.line4Mode;
+        if (settings.showMapBg !== undefined) showMapBg = settings.showMapBg;
+        if (settings.fontSize !== undefined) fontSize = settings.fontSize;
+        if (settings.altFilterLow !== undefined) altFilterLow = settings.altFilterLow;
+        if (settings.altFilterHigh !== undefined) altFilterHigh = settings.altFilterHigh;
+        if (settings.ldbBrightness !== undefined) ldbBrightness = settings.ldbBrightness;
+        if (settings.facilityOnly !== undefined) facilityOnly = settings.facilityOnly;
+        if (settings.mcaKb !== undefined) document.getElementById('chk-mca-kb').checked = settings.mcaKb;
+        if (settings.numinv !== undefined) document.getElementById('numpad-inverted').checked = !settings.numinv;
+        if (settings.nasrBrightness) Object.assign(nasrBrightness, settings.nasrBrightness);
+        if (settings.nexradLevel !== undefined) nexradLevel = settings.nexradLevel;
+        if (settings.nexradBrightness !== undefined) nexradBrightness = settings.nexradBrightness;
+        if (settings.scopeBckgrd !== undefined) scopeBckgrd = settings.scopeBckgrd;
+        if (settings.scopeBcklght !== undefined) scopeBcklght = settings.scopeBcklght;
+        if (settings.tbVisible !== undefined) window._tbVisible = settings.tbVisible;
+
+        // Restore map position/zoom
+        if (settings.mapCenter && settings.mapZoom !== undefined) {
+            map.setView([settings.mapCenter.lat, settings.mapCenter.lng], settings.mapZoom);
+        }
+    } catch (e) {
+        console.warn('Failed to load settings from localStorage:', e);
     }
 
     // Apply to UI controls
@@ -3560,49 +3540,40 @@ function loadSettingsFromUrl() {
     updateScopeBackground();
 }
 
-function saveSettingsToUrl() {
-    const params = new URLSearchParams();
-    if (myFacility) params.set('facility', myFacility);
-    if (mySectors.size) params.set('sectors', [...mySectors].join(','));
-    if (!showFdb) params.set('fdb', '0');
-    if (!showHistory) params.set('history', '0');
-    if (MAX_HISTORY !== 5) params.set('histcount', MAX_HISTORY);
-    if (vectorMinutes !== 0) params.set('vector', vectorMinutes);
-    const brVals = BOUNDARY_CATS.map(c => boundaryBrightness[c]);
-    const defaultBr = [60, 60, 60, 30];
-    if (brVals.join(',') !== defaultBr.join(',')) params.set('bndbr', brVals.join(','));
-    if (line4Mode !== 'DEST') params.set('line4', line4Mode);
-    if (showMapBg) params.set('mapbg', '1');
-    // if (document.getElementById('chk-transp-mca').checked) params.set('tmca', '1');
-    if (fontSize !== 10) params.set('fontsize', fontSize);
-    if (altFilterLow !== 0) params.set('altlow', altFilterLow);
-    if (altFilterHigh !== 999) params.set('althigh', altFilterHigh);
-    if (ldbBrightness !== 30) params.set('ldb', ldbBrightness);
-    if (facilityOnly) params.set('faconly', '1');
-    if (document.getElementById('chk-mca-kb').checked) params.set('kb', '1');
-    if (!document.getElementById('numpad-inverted').checked) params.set('numinv', '1');
-    const nasrVals = [nasrBrightness.jroutes, nasrBrightness.vroutes, nasrBrightness.vors, nasrBrightness.airports, nasrBrightness.centerlines, nasrBrightness.proc];
-    const nasrDefaults = [0, 0, 15, 0, 0, 0];
-    if (nasrVals.join(',') !== nasrDefaults.join(',')) params.set('nasrbr', nasrVals.join(','));
-    if (nexradLevel !== 3) params.set('nxlvl', nexradLevel === 0 ? '0' : nexradLevel === 2 ? '23' : nexradLevel === 1 ? '3' : '123');
-    if (nexradBrightness !== 30) params.set('nxbr', nexradBrightness);
-    if (scopeBckgrd !== 50) params.set('bckgrd', scopeBckgrd);
-    if (scopeBcklght !== 90) params.set('bcklght', scopeBcklght);
-    // Toolbar visibility (default on; tb=0 to hide)
-    if (!window._tbVisible) params.set('tb', '0');
-    // Replay state
-    if (replayActive && replayCurrentTime) {
-        params.set('replay', replayCurrentTime);
-        const spd = replaySpeedSel?.value;
-        if (spd && spd !== '1') params.set('rspd', spd);
+function saveSettingsToLocalStorage() {
+    const settings = {
+        facility: myFacility,
+        sectors: [...mySectors],
+        showFdb,
+        showHistory,
+        MAX_HISTORY,
+        vectorMinutes,
+        boundaryBrightness,
+        line4Mode,
+        showMapBg,
+        fontSize,
+        altFilterLow,
+        altFilterHigh,
+        ldbBrightness,
+        facilityOnly,
+        mcaKb: document.getElementById('chk-mca-kb')?.checked || false,
+        numinv: !document.getElementById('numpad-inverted')?.checked,
+        nasrBrightness,
+        nexradLevel,
+        nexradBrightness,
+        scopeBckgrd,
+        scopeBcklght,
+        tbVisible: window._tbVisible,
+        tbState: { bright: tbState.bright },
+        // Map position/zoom
+        mapCenter: map.getCenter(),
+        mapZoom: map.getZoom()
+    };
+    try {
+        localStorage.setItem('eram-settings', JSON.stringify(settings));
+    } catch (e) {
+        console.warn('Failed to save settings to localStorage:', e);
     }
-    // Map position/zoom
-    const center = map.getCenter();
-    params.set('lat', center.lat.toFixed(4));
-    params.set('lng', center.lng.toFixed(4));
-    params.set('z', map.getZoom());
-    const hash = params.toString();
-    history.replaceState(null, '', hash ? '#' + hash : window.location.pathname);
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -5110,7 +5081,7 @@ function processCommand(cmd) {
         }
 
         invalidateAllMarkers();
-        saveSettingsToUrl();
+        saveSettingsToLocalStorage();
 
         feedback.unshift({ type: 'ok', text: 'ACCEPT' });
         if (myFacility) feedback.splice(1, 0, { type: 'info', text: `FAC: ${myFacility}` });
@@ -5212,7 +5183,7 @@ document.addEventListener('keydown', e => {
         const next = idx < vectorSteps.length - 1 ? vectorSteps[idx + 1] : vectorSteps[vectorSteps.length - 1];
         vectorMinutes = next;
         document.getElementById('sel-vector').value = vectorMinutes;
-        saveSettingsToUrl();
+        saveSettingsToLocalStorage();
         e.preventDefault(); return;
     }
     if (e.key === 'PageDown' && !e.ctrlKey) {
@@ -5220,7 +5191,7 @@ document.addEventListener('keydown', e => {
         const next = idx > 0 ? vectorSteps[idx - 1] : vectorSteps[0];
         vectorMinutes = next;
         document.getElementById('sel-vector').value = vectorMinutes;
-        saveSettingsToUrl();
+        saveSettingsToLocalStorage();
         e.preventDefault(); return;
     }
 
@@ -5928,7 +5899,7 @@ document.getElementById('fm-body').addEventListener('auxclick', e => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// Toolbar state (must be global for updateToolbarBrightness access, and BEFORE loadSettingsFromUrl)
+// Toolbar state (must be global for updateToolbarBrightness access, and BEFORE loadSettingsFromLocalStorage)
 // ════════════════════════════════════════════════════════════════════════════
 const tbState = {
     masterVisible: false,
@@ -5945,10 +5916,23 @@ const tbState = {
     cursorSize: 1,
 };
 
+// Restore toolbar brightness state from localStorage (must be AFTER tbState is defined)
+try {
+    const saved = localStorage.getItem('eram-settings');
+    if (saved) {
+        const settings = JSON.parse(saved);
+        if (settings.tbState && settings.tbState.bright) {
+            Object.assign(tbState.bright, settings.tbState.bright);
+        }
+    }
+} catch (e) {
+    console.warn('Failed to restore toolbar brightness state:', e);
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // Init
 // ════════════════════════════════════════════════════════════════════════════
-loadSettingsFromUrl();
+loadSettingsFromLocalStorage();
 rebuildFacilityDropdown();
 rebuildSectorCheckboxes();
 
@@ -5956,7 +5940,7 @@ rebuildSectorCheckboxes();
 let _mapSaveTimer = null;
 map.on('moveend', () => {
     clearTimeout(_mapSaveTimer);
-    _mapSaveTimer = setTimeout(saveSettingsToUrl, 500);
+    _mapSaveTimer = setTimeout(saveSettingsToLocalStorage, 500);
 });
 
 window.idleOnPause = () => { if (_ws) { _ws.onclose = null; _ws.close(); _ws = null; } };
@@ -5966,7 +5950,7 @@ document.getElementById('cmd-help-btn').onclick = () => {
     const p = document.getElementById('cmd-help-popup');
     p.style.display = p.style.display === 'block' ? 'none' : 'block';
 };
-document.getElementById('numpad-inverted').addEventListener('change', saveSettingsToUrl);
+document.getElementById('numpad-inverted').addEventListener('change', saveSettingsToLocalStorage);
 
 // ════════════════════════════════════════════════════════════════════════════
 // Master Toolbar System
@@ -6244,11 +6228,11 @@ const TB_BRIGHT = {
         [
             menu('MAP\nBRIGHT', 'map-bright', { cls: 'tb-blue' }),
             nosim('CPDLC', { cls: 'tb-blue' }),
-            incdec('BCKGRD', { cls: 'tb-green', getValue: () => tbState.bright.bckgrd, formatValue: v => v, onDec: () => { scopeBckgrd = Math.max(0, scopeBckgrd - 10); tbState.bright.bckgrd = scopeBckgrd; updateScopeBackground(); saveSettingsToUrl(); }, onInc: () => { scopeBckgrd = Math.min(100, scopeBckgrd + 10); tbState.bright.bckgrd = scopeBckgrd; updateScopeBackground(); saveSettingsToUrl(); } }),
+            incdec('BCKGRD', { cls: 'tb-green', getValue: () => tbState.bright.bckgrd, formatValue: v => v, onDec: () => { scopeBckgrd = Math.max(0, scopeBckgrd - 10); tbState.bright.bckgrd = scopeBckgrd; updateScopeBackground(); saveSettingsToLocalStorage(); }, onInc: () => { scopeBckgrd = Math.min(100, scopeBckgrd + 10); tbState.bright.bckgrd = scopeBckgrd; updateScopeBackground(); saveSettingsToLocalStorage(); } }),
             incdec('CURSOR', { cls: 'tb-green', getValue: () => tbState.bright.cursor, formatValue: v => v, onDec: () => { tbState.bright.cursor = Math.max(0, tbState.bright.cursor - 10); }, onInc: () => { tbState.bright.cursor = Math.min(100, tbState.bright.cursor + 10); } }),
-            incdec('TEXT', { cls: 'tb-green', getValue: () => tbState.bright.text, formatValue: v => v, onDec: () => { tbState.bright.text = Math.max(0, tbState.bright.text - 10); updateTextBrightness(); saveSettingsToUrl(); }, onInc: () => { tbState.bright.text = Math.min(100, tbState.bright.text + 10); updateTextBrightness(); saveSettingsToUrl(); } }),
-            incdec('PR TGT', { cls: 'tb-green', getValue: () => tbState.bright.prTgtr, formatValue: v => v, onDec: () => { tbState.bright.prTgtr = Math.max(0, tbState.bright.prTgtr - 10); saveSettingsToUrl(); }, onInc: () => { tbState.bright.prTgtr = Math.min(100, tbState.bright.prTgtr + 10); saveSettingsToUrl(); } }),
-            incdec('UNP TGT', { cls: 'tb-green', getValue: () => tbState.bright.unpTgt, formatValue: v => v, onDec: () => { tbState.bright.unpTgt = Math.max(0, tbState.bright.unpTgt - 10); saveSettingsToUrl(); }, onInc: () => { tbState.bright.unpTgt = Math.min(100, tbState.bright.unpTgt + 10); saveSettingsToUrl(); } }),
+            incdec('TEXT', { cls: 'tb-green', getValue: () => tbState.bright.text, formatValue: v => v, onDec: () => { tbState.bright.text = Math.max(0, tbState.bright.text - 10); updateTextBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.text = Math.min(100, tbState.bright.text + 10); updateTextBrightness(); saveSettingsToLocalStorage(); } }),
+            incdec('PR TGT', { cls: 'tb-green', getValue: () => tbState.bright.prTgtr, formatValue: v => v, onDec: () => { tbState.bright.prTgtr = Math.max(0, tbState.bright.prTgtr - 10); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.prTgtr = Math.min(100, tbState.bright.prTgtr + 10); saveSettingsToLocalStorage(); } }),
+            incdec('UNP TGT', { cls: 'tb-green', getValue: () => tbState.bright.unpTgt, formatValue: v => v, onDec: () => { tbState.bright.unpTgt = Math.max(0, tbState.bright.unpTgt - 10); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.unpTgt = Math.min(100, tbState.bright.unpTgt + 10); saveSettingsToLocalStorage(); } }),
             incdec('PR HST', { cls: 'tb-green', getValue: () => tbState.bright.prHist, formatValue: v => v, onDec: () => { tbState.bright.prHist = Math.max(0, tbState.bright.prHist - 10); }, onInc: () => { tbState.bright.prHist = Math.min(100, tbState.bright.prHist + 10); } }),
             incdec('UNP HST', { cls: 'tb-green', getValue: () => tbState.bright.unpHist, formatValue: v => v, onDec: () => { tbState.bright.unpHist = Math.max(0, tbState.bright.unpHist - 10); }, onInc: () => { tbState.bright.unpHist = Math.min(100, tbState.bright.unpHist + 10); } }),
             incdec('LDB', {
@@ -6269,10 +6253,10 @@ const TB_BRIGHT = {
             }),
         ],
         [
-            incdec('BCKLGHT', { cls: 'tb-green', getValue: () => tbState.bright.bcklght, formatValue: v => v, onDec: () => { scopeBcklght = Math.max(0, scopeBcklght - 10); tbState.bright.bcklght = scopeBcklght; updateScopeBackground(); saveSettingsToUrl(); }, onInc: () => { scopeBcklght = Math.min(100, scopeBcklght + 10); tbState.bright.bcklght = scopeBcklght; updateScopeBackground(); saveSettingsToUrl(); } }),
-            incdec('BUTTON', { cls: 'tb-green', getValue: () => tbState.bright.button, formatValue: v => v, onDec: () => { tbState.bright.button = Math.max(0, tbState.bright.button - 10); updateButtonBrightness(); saveSettingsToUrl(); }, onInc: () => { tbState.bright.button = Math.min(100, tbState.bright.button + 10); updateButtonBrightness(); saveSettingsToUrl(); } }),
-            incdec('BORDER', { cls: 'tb-green', getValue: () => tbState.bright.border, formatValue: v => v, onDec: () => { tbState.bright.border = Math.max(0, tbState.bright.border - 10); updateBorderBrightness(); saveSettingsToUrl(); }, onInc: () => { tbState.bright.border = Math.min(100, tbState.bright.border + 10); updateBorderBrightness(); saveSettingsToUrl(); } }),
-            incdec('TOOLBAR', { cls: 'tb-green', getValue: () => tbState.bright.toolbar, formatValue: v => v, onDec: () => { tbState.bright.toolbar = Math.max(0, tbState.bright.toolbar - 10); updateToolbarBackgroundBrightness(); saveSettingsToUrl(); }, onInc: () => { tbState.bright.toolbar = Math.min(100, tbState.bright.toolbar + 10); updateToolbarBackgroundBrightness(); saveSettingsToUrl(); } }),
+            incdec('BCKLGHT', { cls: 'tb-green', getValue: () => tbState.bright.bcklght, formatValue: v => v, onDec: () => { scopeBcklght = Math.max(0, scopeBcklght - 10); tbState.bright.bcklght = scopeBcklght; updateScopeBackground(); saveSettingsToLocalStorage(); }, onInc: () => { scopeBcklght = Math.min(100, scopeBcklght + 10); tbState.bright.bcklght = scopeBcklght; updateScopeBackground(); saveSettingsToLocalStorage(); } }),
+            incdec('BUTTON', { cls: 'tb-green', getValue: () => tbState.bright.button, formatValue: v => v, onDec: () => { tbState.bright.button = Math.max(0, tbState.bright.button - 10); updateButtonBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.button = Math.min(100, tbState.bright.button + 10); updateButtonBrightness(); saveSettingsToLocalStorage(); } }),
+            incdec('BORDER', { cls: 'tb-green', getValue: () => tbState.bright.border, formatValue: v => v, onDec: () => { tbState.bright.border = Math.max(0, tbState.bright.border - 10); updateBorderBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.border = Math.min(100, tbState.bright.border + 10); updateBorderBrightness(); saveSettingsToLocalStorage(); } }),
+            incdec('TOOLBAR', { cls: 'tb-green', getValue: () => tbState.bright.toolbar, formatValue: v => v, onDec: () => { tbState.bright.toolbar = Math.max(0, tbState.bright.toolbar - 10); updateToolbarBackgroundBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.toolbar = Math.min(100, tbState.bright.toolbar + 10); updateToolbarBackgroundBrightness(); saveSettingsToLocalStorage(); } }),
             incdec('TB BRDR', { cls: 'tb-green', getValue: () => tbState.bright.tbBrdr, formatValue: v => v, onDec: () => { tbState.bright.tbBrdr = Math.max(0, tbState.bright.tbBrdr - 10); }, onInc: () => { tbState.bright.tbBrdr = Math.min(100, tbState.bright.tbBrdr + 10); } }),
             nosim('AB BRDR'),
             incdec('FDB', { cls: 'tb-green', getValue: () => tbState.bright.fdb, formatValue: v => v, onDec: () => { tbState.bright.fdb = Math.max(0, tbState.bright.fdb - 10); }, onInc: () => { tbState.bright.fdb = Math.min(100, tbState.bright.fdb + 10); } }),
@@ -6929,7 +6913,7 @@ function toggleMasterToolbar() {
         refreshAllButtons();
     }
     window._tbVisible = tbState.masterVisible;
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 }
 
 // ── URL persistence for toolbar visibility ──
@@ -7169,7 +7153,7 @@ function stopReplay() {
     replayBar.style.display = 'none';
     replayStatusEl.textContent = '';
     replayTimeEl.textContent = '';
-    saveSettingsToUrl();
+    saveSettingsToLocalStorage();
 
     // Reconnect to live
     connectWs();
@@ -7181,7 +7165,7 @@ function replayThrottleSave() {
     if (_replaySaveTimer) return;
     _replaySaveTimer = setTimeout(() => {
         _replaySaveTimer = null;
-        saveSettingsToUrl();
+        saveSettingsToLocalStorage();
     }, 3000);
 }
 

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -23,10 +23,14 @@ let msgRate = 0;
 let altFilterLow = 0;      // FL (hundreds of feet), 0 = no filter
 let altFilterHigh = 999;    // FL (hundreds of feet), 999 = no filter
 let fontSize = 10;          // data block font size in px
-let ldbBrightness = 30;     // 0-100, opacity for LDB data blocks (0=hidden, 100=same as FDB)
+let ldbBrightness = 50;     // 0-100, opacity for LDB history symbols (data block brightness now controlled by PR/UNP TGT sliders)
+let scopeBckgrd = 50;       // 0-100, scope background brightness (BCKGRD DCB slider)
+let scopeBcklght = 90;      // 0-100, scope backlight brightness (BCKLGHT DCB slider)
 let showPortalFence = true; // two corner brackets on FDB with PO/R indicators
 let showMapBg = false;      // tile layer hidden by default
 let line4Mode = 'DEST';     // 'DEST' | 'TYPE' | 'OFF' — what FDB line 4 shows
+let replayActive = false;   // replay mode active (set by replay system IIFE)
+let replayCurrentTime = null; // ISO string of current replay position
 const quickLookSectors = new Set(); // QL sectors — force FDB on tracks in these sectors without claiming ownership
 const quickLookDests = new Set();   // QL destinations — force FDB on flights to these airports (e.g. KCLT, KGSO)
 const fdbOverrides = new Map(); // gufi → true/false — user toggle for FDB/LDB per track
@@ -2741,6 +2745,169 @@ document.getElementById('inp-alt-high').addEventListener('change', function () {
     saveSettingsToUrl();
 });
 
+function updateScopeBackground() {
+    const b = scopeBckgrd / 100;
+    const l = scopeBcklght / 100;
+    const blue = Math.floor(b * (82 + 45 * l));
+    const color = `rgb(0,0,${blue})`;
+    const lc = document.querySelector('.leaflet-container');
+    if (lc) lc.style.setProperty('background', color, 'important');
+
+    // Apply backlight to toolbar
+    const toolbarPanel = document.getElementById('master-toolbar-container');
+    if (toolbarPanel) {
+        const backlightFactor = 0.6 + (l * 0.5);
+        toolbarPanel.style.filter = `brightness(${backlightFactor})`;
+    }
+
+    updateToolbarBrightness();
+}
+
+function updateButtonBrightness() {
+    updateToolbarBrightness();
+}
+
+function updateBorderBrightness() {
+    try {
+        // Border brightness: 0-1, where 1=white, 0=black
+        const borderFactor = tbState.bright.border / 100;
+
+        // Create or update dynamic CSS for borders
+        let styleEl = document.getElementById('dynamic-border-brightness');
+        if (!styleEl) {
+            styleEl = document.createElement('style');
+            styleEl.id = 'dynamic-border-brightness';
+            document.head.appendChild(styleEl);
+        }
+
+        // Interpolate border color from white (at 100) to black (at 0)
+        const borderColor = interpolateColor('#FFFFFF', borderFactor);
+
+        styleEl.textContent = `
+            .tb-btn {
+                border-top-color: ${borderColor} !important;
+                border-right-color: ${borderColor} !important;
+                border-bottom-color: ${borderColor} !important;
+                border-left-color: ${borderColor} !important;
+            }
+            .tb-btn .tb-tear { border-right-color: ${borderColor} !important; }
+        `;
+    } catch (e) {
+        // tbState not yet initialized
+    }
+}
+
+function updateToolbarBackgroundBrightness() {
+    try {
+        // Toolbar brightness: 0-1, where 1=#C5C5C5 (light gray), 0=black
+        const toolbarFactor = tbState.bright.toolbar / 100;
+
+        // Create or update dynamic CSS for toolbar background
+        let styleEl = document.getElementById('dynamic-toolbar-bg-brightness');
+        if (!styleEl) {
+            styleEl = document.createElement('style');
+            styleEl.id = 'dynamic-toolbar-bg-brightness';
+            document.head.appendChild(styleEl);
+        }
+
+        // Interpolate toolbar background from light gray (at 100) to black (at 0)
+        const toolbarBgColor = interpolateColor('#C5C5C5', toolbarFactor);
+
+        styleEl.textContent = `
+            #master-toolbar-container { background-color: ${toolbarBgColor} !important; }
+            .tb-master-grid { background-color: ${toolbarBgColor} !important; }
+            .tb-submenu { background-color: ${toolbarBgColor} !important; }
+        `;
+    } catch (e) {
+        // tbState not yet initialized
+    }
+}
+
+function updateTextBrightness() {
+    try {
+        // Text brightness: 0-1, where 1=#F3F3F3 (light gray/white), 0=black
+        const textFactor = tbState.bright.text / 100;
+
+        // Create or update dynamic CSS for text color
+        let styleEl = document.getElementById('dynamic-text-brightness');
+        if (!styleEl) {
+            styleEl = document.createElement('style');
+            styleEl.id = 'dynamic-text-brightness';
+            document.head.appendChild(styleEl);
+        }
+
+        // Interpolate text color from light gray (at 100) to black (at 0)
+        const textColor = interpolateColor('#F3F3F3', textFactor);
+
+        styleEl.textContent = `
+            .tb-btn .tb-label { color: ${textColor} !important; }
+            .tb-btn .tb-value { color: ${textColor} !important; }
+            .tb-btn .tb-menu-ind { color: ${textColor} !important; }
+        `;
+    } catch (e) {
+        // tbState not yet initialized
+    }
+}
+
+function interpolateColor(hexColor, factor) {
+    // Parse hex color (e.g., #00CD00 -> [0, 205, 0])
+    const r = parseInt(hexColor.slice(1, 3), 16);
+    const g = parseInt(hexColor.slice(3, 5), 16);
+    const b = parseInt(hexColor.slice(5, 7), 16);
+
+    // Interpolate toward black: color * factor + black * (1 - factor)
+    const newR = Math.round(r * factor);
+    const newG = Math.round(g * factor);
+    const newB = Math.round(b * factor);
+
+    return `rgb(${newR}, ${newG}, ${newB})`;
+}
+
+function updateToolbarBrightness() {
+    try {
+        // Button brightness: 0-1, where 1=full color, 0=black
+        const buttonFactor = tbState.bright.button / 100;
+
+        // Create or update dynamic CSS for button backgrounds
+        let styleEl = document.getElementById('dynamic-button-brightness');
+        if (!styleEl) {
+            styleEl = document.createElement('style');
+            styleEl.id = 'dynamic-button-brightness';
+            document.head.appendChild(styleEl);
+        }
+
+        // Define original button colors
+        const colors = {
+            'tb-green': '#00CD00',
+            'tb-blue': '#0000D4',
+            'tb-tan': '#DCA09B',
+            'tb-teal': '#00C7D1',
+            'tb-dark': '#000000',
+            'tb-toggle-grey-off': '#000000',
+            'tb-nosim': '#000066',
+            'tb-toggle-on': '#0000D4',
+            'tb-menu-open': '#DCA09B',
+        };
+
+        // Generate CSS with interpolated colors
+        let css = '';
+        for (const [className, color] of Object.entries(colors)) {
+            const interpolated = interpolateColor(color, buttonFactor);
+            css += `.tb-btn.${className} { background: ${interpolated} !important; }\n`;
+        }
+
+        // Default button color
+        css += `.tb-btn { background: ${interpolateColor('#0000D4', buttonFactor)} !important; }\n`;
+
+        // Tearoff strip color (interpolate toward black)
+        css += `.tb-btn .tb-tear { background: ${interpolateColor('#FFFFA1', buttonFactor)} !important; }\n`;
+
+        styleEl.textContent = css;
+    } catch (e) {
+        // tbState not yet initialized
+    }
+}
+
 function updateFontSize() {
     CHAR_W = fontSize * 0.625;
     LINE_H = fontSize * 1.25;
@@ -3333,6 +3500,8 @@ function loadSettingsFromUrl() {
         nexradLevel = v === '123' ? 3 : v === '23' ? 2 : v === '3' ? 1 : 0;
     }
     if (params.has('nxbr')) nexradBrightness = parseInt(params.get('nxbr'));
+    if (params.has('bckgrd')) scopeBckgrd = Math.max(0, Math.min(100, parseInt(params.get('bckgrd')) || 100));
+    if (params.has('bcklght')) scopeBcklght = Math.max(0, Math.min(100, parseInt(params.get('bcklght')) || 100));
     if (params.get('tb') === '0') window._tbVisible = false;
 
     // Restore map position/zoom
@@ -3388,6 +3557,7 @@ function loadSettingsFromUrl() {
         fetch('/api/nasr/centerlines').then(r => r.ok ? r.json() : null).then(d => { if (d) { centerlineData = d; drawOverlay(); } });
     }
     showBoundariesForFacility(myFacility);
+    updateScopeBackground();
 }
 
 function saveSettingsToUrl() {
@@ -3416,6 +3586,8 @@ function saveSettingsToUrl() {
     if (nasrVals.join(',') !== nasrDefaults.join(',')) params.set('nasrbr', nasrVals.join(','));
     if (nexradLevel !== 3) params.set('nxlvl', nexradLevel === 0 ? '0' : nexradLevel === 2 ? '23' : nexradLevel === 1 ? '3' : '123');
     if (nexradBrightness !== 30) params.set('nxbr', nexradBrightness);
+    if (scopeBckgrd !== 50) params.set('bckgrd', scopeBckgrd);
+    if (scopeBcklght !== 90) params.set('bcklght', scopeBcklght);
     // Toolbar visibility (default on; tb=0 to hide)
     if (!window._tbVisible) params.set('tb', '0');
     // Replay state
@@ -5756,6 +5928,24 @@ document.getElementById('fm-body').addEventListener('auxclick', e => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
+// Toolbar state (must be global for updateToolbarBrightness access, and BEFORE loadSettingsFromUrl)
+// ════════════════════════════════════════════════════════════════════════════
+const tbState = {
+    masterVisible: false,
+    openMenu: null,       // currently open sub-menu id string
+    openSubMenu: null,    // nested sub-menu id (e.g. 'weather' under 'atc-tools')
+    // Brightness values (0-100) for buttons not yet wired
+    bright: {
+        bckgrd: scopeBckgrd, cursor: 50, text: 100, prTgtr: 50, unpTgt: 50,
+        prHist: 50, unpHist: 50, sldb: 50, bcklght: 90, button: 80,
+        border: 50, toolbar: 50, tbBrdr: 50, fdb: 50, portal: 50,
+        onFreq: 50, line4b: 50, dwell: 50, fence: 50,
+    },
+    // Cursor sub-menu
+    cursorSize: 1,
+};
+
+// ════════════════════════════════════════════════════════════════════════════
 // Init
 // ════════════════════════════════════════════════════════════════════════════
 loadSettingsFromUrl();
@@ -5782,22 +5972,6 @@ document.getElementById('numpad-inverted').addEventListener('change', saveSettin
 // Master Toolbar System
 // ════════════════════════════════════════════════════════════════════════════
 (function () {
-
-// ── Toolbar state ──
-const tbState = {
-    masterVisible: false,
-    openMenu: null,       // currently open sub-menu id string
-    openSubMenu: null,    // nested sub-menu id (e.g. 'weather' under 'atc-tools')
-    // Brightness values (0-100) for buttons not yet wired
-    bright: {
-        bckgrd: 50, cursor: 50, text: 50, prTgtr: 50, unpTgt: 50,
-        prHist: 50, unpHist: 50, sldb: 50, bcklght: 50, button: 50,
-        border: 50, toolbar: 50, tbBrdr: 50, fdb: 50, portal: 50,
-        onFreq: 50, line4b: 50, dwell: 50, fence: 50,
-    },
-    // Cursor sub-menu
-    cursorSize: 1,
-};
 
 // ── Helper: approximate range NM from zoom ──
 function zoomToRange(z) {
@@ -5841,8 +6015,8 @@ function nxlvlLabel(val) {
 const FONT_STEPS = [8, 9, 10, 11, 12, 14];
 
 // ── Button spec builder helpers ──
-function nosim(label) { return { label, type: 'nosim' }; }
-function menu(label, menuId) { return { label, type: 'menu', menu: menuId }; }
+function nosim(label, opts) { return { label, type: 'nosim', ...opts }; }
+function menu(label, menuId, opts) { return { label, type: 'menu', menu: menuId, ...opts }; }
 function toggle(label, opts) { return { label, type: 'toggle', ...opts }; }
 function incdec(label, opts) { return { label, type: 'incdec', ...opts }; }
 function cmd(label, opts) { return { label, type: 'cmd', ...opts }; }
@@ -6019,36 +6193,44 @@ const TB_GEOMAP = {
     rows: [
         [
             toggle('UHI', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getRangeVal('rng-bnd-uhi') > 0,
                 onToggle: (on) => setRangeVal('rng-bnd-uhi', on ? 60 : 0),
             }),
             toggle('HI', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getRangeVal('rng-bnd-hi') > 0,
                 onToggle: (on) => setRangeVal('rng-bnd-hi', on ? 60 : 0),
             }),
             toggle('LO', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getRangeVal('rng-bnd-lo') > 0,
                 onToggle: (on) => setRangeVal('rng-bnd-lo', on ? 60 : 0),
             }),
             toggle('APP', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getRangeVal('rng-bnd-app') > 0,
                 onToggle: (on) => setRangeVal('rng-bnd-app', on ? 60 : 0),
             }),
         ],
         [
             toggle('HI AWY', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getRangeVal('rng-jroutes') > 0,
                 onToggle: (on) => setRangeVal('rng-jroutes', on ? 60 : 0),
             }),
             toggle('LO AWY', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getRangeVal('rng-vroutes') > 0,
                 onToggle: (on) => setRangeVal('rng-vroutes', on ? 60 : 0),
             }),
             toggle('VORs', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getRangeVal('rng-vors') > 0,
                 onToggle: (on) => setRangeVal('rng-vors', on ? 60 : 0),
             }),
             toggle('APTs', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getRangeVal('rng-airports') > 0,
                 onToggle: (on) => setRangeVal('rng-airports', on ? 60 : 0),
             }),
@@ -6060,24 +6242,26 @@ const TB_BRIGHT = {
     id: 'bright',
     rows: [
         [
-            menu('MAP\nBRIGHT', 'map-bright'),
-            nosim('CPDLC'),
-            incdec('BCKGRD', { getValue: () => tbState.bright.bckgrd, formatValue: v => v, onDec: () => { tbState.bright.bckgrd = Math.max(0, tbState.bright.bckgrd - 10); }, onInc: () => { tbState.bright.bckgrd = Math.min(100, tbState.bright.bckgrd + 10); } }),
-            incdec('CURSOR', { getValue: () => tbState.bright.cursor, formatValue: v => v, onDec: () => { tbState.bright.cursor = Math.max(0, tbState.bright.cursor - 10); }, onInc: () => { tbState.bright.cursor = Math.min(100, tbState.bright.cursor + 10); } }),
-            incdec('TEXT', { getValue: () => tbState.bright.text, formatValue: v => v, onDec: () => { tbState.bright.text = Math.max(0, tbState.bright.text - 10); }, onInc: () => { tbState.bright.text = Math.min(100, tbState.bright.text + 10); } }),
-            incdec('PR TGT', { getValue: () => tbState.bright.prTgtr, formatValue: v => v, onDec: () => { tbState.bright.prTgtr = Math.max(0, tbState.bright.prTgtr - 10); }, onInc: () => { tbState.bright.prTgtr = Math.min(100, tbState.bright.prTgtr + 10); } }),
-            incdec('UNP TGT', { getValue: () => tbState.bright.unpTgt, formatValue: v => v, onDec: () => { tbState.bright.unpTgt = Math.max(0, tbState.bright.unpTgt - 10); }, onInc: () => { tbState.bright.unpTgt = Math.min(100, tbState.bright.unpTgt + 10); } }),
-            incdec('PR HST', { getValue: () => tbState.bright.prHist, formatValue: v => v, onDec: () => { tbState.bright.prHist = Math.max(0, tbState.bright.prHist - 10); }, onInc: () => { tbState.bright.prHist = Math.min(100, tbState.bright.prHist + 10); } }),
-            incdec('UNP HST', { getValue: () => tbState.bright.unpHist, formatValue: v => v, onDec: () => { tbState.bright.unpHist = Math.max(0, tbState.bright.unpHist - 10); }, onInc: () => { tbState.bright.unpHist = Math.min(100, tbState.bright.unpHist + 10); } }),
+            menu('MAP\nBRIGHT', 'map-bright', { cls: 'tb-blue' }),
+            nosim('CPDLC', { cls: 'tb-blue' }),
+            incdec('BCKGRD', { cls: 'tb-green', getValue: () => tbState.bright.bckgrd, formatValue: v => v, onDec: () => { scopeBckgrd = Math.max(0, scopeBckgrd - 10); tbState.bright.bckgrd = scopeBckgrd; updateScopeBackground(); saveSettingsToUrl(); }, onInc: () => { scopeBckgrd = Math.min(100, scopeBckgrd + 10); tbState.bright.bckgrd = scopeBckgrd; updateScopeBackground(); saveSettingsToUrl(); } }),
+            incdec('CURSOR', { cls: 'tb-green', getValue: () => tbState.bright.cursor, formatValue: v => v, onDec: () => { tbState.bright.cursor = Math.max(0, tbState.bright.cursor - 10); }, onInc: () => { tbState.bright.cursor = Math.min(100, tbState.bright.cursor + 10); } }),
+            incdec('TEXT', { cls: 'tb-green', getValue: () => tbState.bright.text, formatValue: v => v, onDec: () => { tbState.bright.text = Math.max(0, tbState.bright.text - 10); updateTextBrightness(); saveSettingsToUrl(); }, onInc: () => { tbState.bright.text = Math.min(100, tbState.bright.text + 10); updateTextBrightness(); saveSettingsToUrl(); } }),
+            incdec('PR TGT', { cls: 'tb-green', getValue: () => tbState.bright.prTgtr, formatValue: v => v, onDec: () => { tbState.bright.prTgtr = Math.max(0, tbState.bright.prTgtr - 10); saveSettingsToUrl(); }, onInc: () => { tbState.bright.prTgtr = Math.min(100, tbState.bright.prTgtr + 10); saveSettingsToUrl(); } }),
+            incdec('UNP TGT', { cls: 'tb-green', getValue: () => tbState.bright.unpTgt, formatValue: v => v, onDec: () => { tbState.bright.unpTgt = Math.max(0, tbState.bright.unpTgt - 10); saveSettingsToUrl(); }, onInc: () => { tbState.bright.unpTgt = Math.min(100, tbState.bright.unpTgt + 10); saveSettingsToUrl(); } }),
+            incdec('PR HST', { cls: 'tb-green', getValue: () => tbState.bright.prHist, formatValue: v => v, onDec: () => { tbState.bright.prHist = Math.max(0, tbState.bright.prHist - 10); }, onInc: () => { tbState.bright.prHist = Math.min(100, tbState.bright.prHist + 10); } }),
+            incdec('UNP HST', { cls: 'tb-green', getValue: () => tbState.bright.unpHist, formatValue: v => v, onDec: () => { tbState.bright.unpHist = Math.max(0, tbState.bright.unpHist - 10); }, onInc: () => { tbState.bright.unpHist = Math.min(100, tbState.bright.unpHist + 10); } }),
             incdec('LDB', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-ldb-brightness'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-ldb-brightness', Math.max(0, getRangeVal('rng-ldb-brightness') - 10)),
                 onInc: () => setRangeVal('rng-ldb-brightness', Math.min(100, getRangeVal('rng-ldb-brightness') + 10)),
             }),
-            incdec('SLDB', { getValue: () => tbState.bright.sldb, formatValue: v => v, onDec: () => { tbState.bright.sldb = Math.max(0, tbState.bright.sldb - 10); }, onInc: () => { tbState.bright.sldb = Math.min(100, tbState.bright.sldb + 10); } }),
+            incdec('SLDB', { cls: 'tb-green', getValue: () => tbState.bright.sldb, formatValue: v => v, onDec: () => { tbState.bright.sldb = Math.max(0, tbState.bright.sldb - 10); }, onInc: () => { tbState.bright.sldb = Math.min(100, tbState.bright.sldb + 10); } }),
             nosim('WX'),
             incdec('NEXRAD', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-nx'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-nx', Math.max(0, getRangeVal('rng-nx') - 10)),
@@ -6085,19 +6269,19 @@ const TB_BRIGHT = {
             }),
         ],
         [
-            incdec('BCKLGHT', { getValue: () => tbState.bright.bcklght, formatValue: v => v, onDec: () => { tbState.bright.bcklght = Math.max(0, tbState.bright.bcklght - 10); }, onInc: () => { tbState.bright.bcklght = Math.min(100, tbState.bright.bcklght + 10); } }),
-            incdec('BUTTON', { getValue: () => tbState.bright.button, formatValue: v => v, onDec: () => { tbState.bright.button = Math.max(0, tbState.bright.button - 10); }, onInc: () => { tbState.bright.button = Math.min(100, tbState.bright.button + 10); } }),
-            incdec('BORDER', { getValue: () => tbState.bright.border, formatValue: v => v, onDec: () => { tbState.bright.border = Math.max(0, tbState.bright.border - 10); }, onInc: () => { tbState.bright.border = Math.min(100, tbState.bright.border + 10); } }),
-            incdec('TOOLBAR', { getValue: () => tbState.bright.toolbar, formatValue: v => v, onDec: () => { tbState.bright.toolbar = Math.max(0, tbState.bright.toolbar - 10); }, onInc: () => { tbState.bright.toolbar = Math.min(100, tbState.bright.toolbar + 10); } }),
-            incdec('TB BRDR', { getValue: () => tbState.bright.tbBrdr, formatValue: v => v, onDec: () => { tbState.bright.tbBrdr = Math.max(0, tbState.bright.tbBrdr - 10); }, onInc: () => { tbState.bright.tbBrdr = Math.min(100, tbState.bright.tbBrdr + 10); } }),
+            incdec('BCKLGHT', { cls: 'tb-green', getValue: () => tbState.bright.bcklght, formatValue: v => v, onDec: () => { scopeBcklght = Math.max(0, scopeBcklght - 10); tbState.bright.bcklght = scopeBcklght; updateScopeBackground(); saveSettingsToUrl(); }, onInc: () => { scopeBcklght = Math.min(100, scopeBcklght + 10); tbState.bright.bcklght = scopeBcklght; updateScopeBackground(); saveSettingsToUrl(); } }),
+            incdec('BUTTON', { cls: 'tb-green', getValue: () => tbState.bright.button, formatValue: v => v, onDec: () => { tbState.bright.button = Math.max(0, tbState.bright.button - 10); updateButtonBrightness(); saveSettingsToUrl(); }, onInc: () => { tbState.bright.button = Math.min(100, tbState.bright.button + 10); updateButtonBrightness(); saveSettingsToUrl(); } }),
+            incdec('BORDER', { cls: 'tb-green', getValue: () => tbState.bright.border, formatValue: v => v, onDec: () => { tbState.bright.border = Math.max(0, tbState.bright.border - 10); updateBorderBrightness(); saveSettingsToUrl(); }, onInc: () => { tbState.bright.border = Math.min(100, tbState.bright.border + 10); updateBorderBrightness(); saveSettingsToUrl(); } }),
+            incdec('TOOLBAR', { cls: 'tb-green', getValue: () => tbState.bright.toolbar, formatValue: v => v, onDec: () => { tbState.bright.toolbar = Math.max(0, tbState.bright.toolbar - 10); updateToolbarBackgroundBrightness(); saveSettingsToUrl(); }, onInc: () => { tbState.bright.toolbar = Math.min(100, tbState.bright.toolbar + 10); updateToolbarBackgroundBrightness(); saveSettingsToUrl(); } }),
+            incdec('TB BRDR', { cls: 'tb-green', getValue: () => tbState.bright.tbBrdr, formatValue: v => v, onDec: () => { tbState.bright.tbBrdr = Math.max(0, tbState.bright.tbBrdr - 10); }, onInc: () => { tbState.bright.tbBrdr = Math.min(100, tbState.bright.tbBrdr + 10); } }),
             nosim('AB BRDR'),
-            incdec('FDB', { getValue: () => tbState.bright.fdb, formatValue: v => v, onDec: () => { tbState.bright.fdb = Math.max(0, tbState.bright.fdb - 10); }, onInc: () => { tbState.bright.fdb = Math.min(100, tbState.bright.fdb + 10); } }),
-            incdec('PORTAL', { getValue: () => tbState.bright.portal, formatValue: v => v, onDec: () => { tbState.bright.portal = Math.max(0, tbState.bright.portal - 10); }, onInc: () => { tbState.bright.portal = Math.min(100, tbState.bright.portal + 10); } }),
+            incdec('FDB', { cls: 'tb-green', getValue: () => tbState.bright.fdb, formatValue: v => v, onDec: () => { tbState.bright.fdb = Math.max(0, tbState.bright.fdb - 10); }, onInc: () => { tbState.bright.fdb = Math.min(100, tbState.bright.fdb + 10); } }),
+            incdec('PORTAL', { cls: 'tb-green', getValue: () => tbState.bright.portal, formatValue: v => v, onDec: () => { tbState.bright.portal = Math.max(0, tbState.bright.portal - 10); }, onInc: () => { tbState.bright.portal = Math.min(100, tbState.bright.portal + 10); } }),
             nosim('SATCOMM'),
-            incdec('ON-FREQ', { getValue: () => tbState.bright.onFreq, formatValue: v => v, onDec: () => { tbState.bright.onFreq = Math.max(0, tbState.bright.onFreq - 10); }, onInc: () => { tbState.bright.onFreq = Math.min(100, tbState.bright.onFreq + 10); } }),
-            incdec('LINE 4', { getValue: () => tbState.bright.line4b, formatValue: v => v, onDec: () => { tbState.bright.line4b = Math.max(0, tbState.bright.line4b - 10); }, onInc: () => { tbState.bright.line4b = Math.min(100, tbState.bright.line4b + 10); } }),
-            incdec('DWELL', { getValue: () => tbState.bright.dwell, formatValue: v => v, onDec: () => { tbState.bright.dwell = Math.max(0, tbState.bright.dwell - 10); }, onInc: () => { tbState.bright.dwell = Math.min(100, tbState.bright.dwell + 10); } }),
-            incdec('FENCE', { getValue: () => tbState.bright.fence, formatValue: v => v, onDec: () => { tbState.bright.fence = Math.max(0, tbState.bright.fence - 10); }, onInc: () => { tbState.bright.fence = Math.min(100, tbState.bright.fence + 10); } }),
+            incdec('ON-FREQ', { cls: 'tb-green', getValue: () => tbState.bright.onFreq, formatValue: v => v, onDec: () => { tbState.bright.onFreq = Math.max(0, tbState.bright.onFreq - 10); }, onInc: () => { tbState.bright.onFreq = Math.min(100, tbState.bright.onFreq + 10); } }),
+            incdec('LINE 4', { cls: 'tb-green', getValue: () => tbState.bright.line4b, formatValue: v => v, onDec: () => { tbState.bright.line4b = Math.max(0, tbState.bright.line4b - 10); }, onInc: () => { tbState.bright.line4b = Math.min(100, tbState.bright.line4b + 10); } }),
+            incdec('DWELL', { cls: 'tb-green', getValue: () => tbState.bright.dwell, formatValue: v => v, onDec: () => { tbState.bright.dwell = Math.max(0, tbState.bright.dwell - 10); }, onInc: () => { tbState.bright.dwell = Math.min(100, tbState.bright.dwell + 10); } }),
+            incdec('FENCE', { cls: 'tb-green', getValue: () => tbState.bright.fence, formatValue: v => v, onDec: () => { tbState.bright.fence = Math.max(0, tbState.bright.fence - 10); }, onInc: () => { tbState.bright.fence = Math.min(100, tbState.bright.fence + 10); } }),
             nosim('DBFEL'),
             nosim('OUTAGE'),
         ],
@@ -6198,6 +6382,7 @@ const TB_DB_FIELDS = {
             { label: 'CODE', type: 'toggle', nosim: true },
             { label: 'SPEED', type: 'toggle', nosim: true },
             toggle('DEST', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getSelectVal('sel-line4') === 'DEST',
                 onToggle: (on) => {
                     setSelectVal('sel-line4', on ? 'DEST' : 'OFF');
@@ -6205,6 +6390,7 @@ const TB_DB_FIELDS = {
                 },
             }),
             toggle('TYPE', {
+                cls: 'tb-toggle-grey',
                 isOn: () => getSelectVal('sel-line4') === 'TYPE',
                 onToggle: (on) => {
                     setSelectVal('sel-line4', on ? 'TYPE' : 'OFF');
@@ -6219,6 +6405,7 @@ const TB_DB_FIELDS = {
             }),
             { label: 'BCAST\nFLID', type: 'toggle', nosim: true },
             toggle('PORTAL\nFENCE', {
+                cls: 'tb-toggle-grey',
                 isOn: () => showPortalFence,
                 onToggle: (on) => { showPortalFence = on; invalidateAllMarkers(); },
             }),
@@ -6322,8 +6509,9 @@ function createButton(spec, panelId, rowIdx, colIdx) {
     content.appendChild(labelDiv);
 
     // Value (for incdec)
+    let valDiv = null;
     if (spec.type === 'incdec' && spec.getValue) {
-        const valDiv = document.createElement('div');
+        valDiv = document.createElement('div');
         valDiv.className = 'tb-value';
         valDiv.textContent = spec.formatValue(spec.getValue());
         content.appendChild(valDiv);
@@ -6344,8 +6532,8 @@ function createButton(spec, panelId, rowIdx, colIdx) {
         el.classList.add('tb-toggle-on');
     }
 
-    // Store reference
-    tbElements.set(key, { el, spec });
+    // Store reference (include valDiv for incdec buttons to avoid query overhead)
+    tbElements.set(key, { el, spec, valDiv });
 
     // Event handling
     if (!isNosim) {
@@ -6401,13 +6589,17 @@ function renderPanel(spec, container) {
 function refreshButton(key) {
     const entry = tbElements.get(key);
     if (!entry) return;
-    const { el, spec } = entry;
+    const { el, spec, valDiv } = entry;
     const isNosim = spec.type === 'nosim' || spec.nosim;
 
-    // Update value display
-    if (spec.type === 'incdec' && spec.getValue) {
-        const valEl = el.querySelector('.tb-value');
-        if (valEl) valEl.textContent = spec.formatValue(spec.getValue());
+    // Update value display (if valDiv exists and getValue is defined)
+    if (valDiv && spec.getValue) {
+        const newValue = String(spec.formatValue(spec.getValue()));
+        valDiv.textContent = newValue;
+        // Force browser repaint of the entire button
+        if (el && el.offsetHeight) {
+            void el.offsetHeight;
+        }
     }
 
     // Update toggle state
@@ -6439,7 +6631,12 @@ function refreshAllSubMenus() {
 function closeAllSubMenus() {
     tbState.openMenu = null;
     tbState.openSubMenu = null;
-    if (subMenuContainerEl) { subMenuContainerEl.innerHTML = ''; subMenuContainerEl.style.display = 'none'; subMenuContainerEl.style.left = ''; subMenuContainerEl.style.top = ''; subMenuContainerEl.style.maxWidth = ''; subMenuContainerEl.style.overflowX = ''; }
+    if (subMenuContainerEl) {
+        if (subMenuContainerEl._wheelHandler) { subMenuContainerEl.removeEventListener('wheel', subMenuContainerEl._wheelHandler); delete subMenuContainerEl._wheelHandler; }
+        if (subMenuContainerEl._dragDown) { subMenuContainerEl.removeEventListener('mousedown', subMenuContainerEl._dragDown); window.removeEventListener('mousemove', subMenuContainerEl._dragMove); window.removeEventListener('mouseup', subMenuContainerEl._dragUp); delete subMenuContainerEl._dragDown; delete subMenuContainerEl._dragMove; delete subMenuContainerEl._dragUp; }
+        subMenuContainerEl.style.cursor = '';
+        subMenuContainerEl.innerHTML = ''; subMenuContainerEl.style.display = 'none'; subMenuContainerEl.style.left = ''; subMenuContainerEl.style.top = ''; subMenuContainerEl.style.maxWidth = ''; subMenuContainerEl.style.overflowX = ''; subMenuContainerEl.scrollLeft = 0;
+    }
     if (subSubMenuContainerEl) { subSubMenuContainerEl.innerHTML = ''; subSubMenuContainerEl.style.display = 'none'; subSubMenuContainerEl.style.left = ''; subSubMenuContainerEl.style.top = ''; }
     // Restore all master buttons visibility and remove pink state
     if (masterPanelEl) {
@@ -6513,6 +6710,29 @@ function openSubMenu(menuId, anchorEl) {
         if (menuRect.right > window.innerWidth - 4) {
             subMenuContainerEl.style.maxWidth = (window.innerWidth - menuRect.left - 4) + 'px';
             subMenuContainerEl.style.overflowX = 'auto';
+            subMenuContainerEl._wheelHandler = (e) => {
+                if (e.deltaY !== 0) { e.preventDefault(); subMenuContainerEl.scrollLeft += e.deltaY; }
+            };
+            subMenuContainerEl.addEventListener('wheel', subMenuContainerEl._wheelHandler, { passive: false });
+            // Drag-to-scroll
+            let _dragX = null, _dragScroll = 0;
+            subMenuContainerEl._dragDown = (e) => {
+                if (e.button !== 0) return;
+                _dragX = e.clientX; _dragScroll = subMenuContainerEl.scrollLeft;
+                subMenuContainerEl.style.cursor = 'grabbing';
+                e.preventDefault();
+            };
+            subMenuContainerEl._dragMove = (e) => {
+                if (_dragX === null) return;
+                subMenuContainerEl.scrollLeft = _dragScroll - (e.clientX - _dragX);
+            };
+            subMenuContainerEl._dragUp = () => {
+                _dragX = null; subMenuContainerEl.style.cursor = 'grab';
+            };
+            subMenuContainerEl.style.cursor = 'grab';
+            subMenuContainerEl.addEventListener('mousedown', subMenuContainerEl._dragDown);
+            window.addEventListener('mousemove', subMenuContainerEl._dragMove);
+            window.addEventListener('mouseup', subMenuContainerEl._dragUp);
         }
     }
     refreshAllButtons();
@@ -6561,7 +6781,7 @@ function buildInlineSubMenu(menuSpec, menuId, container, parentRow) {
 
         if (ri === 0) {
             const parentLabel = MENU_LABELS[menuId] || menuId.toUpperCase();
-            const parentSpec = { label: parentLabel, type: 'menu', menu: menuId };
+            const parentSpec = { label: parentLabel, type: 'menu', menu: menuId, cls: 'tb-tan' };
             const parentBtn = createButton(parentSpec, menuSpec.id + '-parent', 0, 0);
             parentBtn.classList.add('tb-menu-open');
             rowEl.appendChild(parentBtn);
@@ -6592,6 +6812,7 @@ function handleBtnAction(spec, key, isMiddle) {
         } else {
             if (spec.onDec) spec.onDec();
         }
+        refreshButton(key);
         refreshAllButtons();
     } else if (spec.type === 'cmd') {
         if (spec.onCmd) spec.onCmd();
@@ -6721,13 +6942,16 @@ if (_tbInitParams.get('tb') !== '0') {
 
 // ── Initialize ──
 buildToolbar();
+refreshAllButtons();  // Refresh button displays to show correct initial values
+updateBorderBrightness();  // Initialize border brightness
+updateToolbarBackgroundBrightness();  // Initialize toolbar background brightness
+updateTextBrightness();  // Initialize text brightness
 
 // Apply initial visibility from URL
 if (tbState.masterVisible) {
     document.getElementById('master-toolbar-container').classList.add('tb-visible');
     document.body.classList.add('tb-active');
     document.getElementById('tb-tearoff-btn').classList.add('tb-active');
-    refreshAllButtons();
 }
 
 })();  // end toolbar IIFE
@@ -6750,9 +6974,7 @@ const replayStopBtn = document.getElementById('replay-stop');
 const replayRangeEl = document.getElementById('replay-range');
 
 let replayWs = null;
-let replayActive = false;
 let replayPaused = false;
-let replayCurrentTime = null; // ISO string of current replay position
 let replayPendingFlights = new Map(); // gufi → latest flight object (merged across batches)
 let replayPendingRemoves = []; // gufi list
 let replayRafId = null;

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -6428,7 +6428,7 @@ function refreshAllSubMenus() {
 function closeAllSubMenus() {
     tbState.openMenu = null;
     tbState.openSubMenu = null;
-    if (subMenuContainerEl) { subMenuContainerEl.innerHTML = ''; subMenuContainerEl.style.display = 'none'; subMenuContainerEl.style.left = ''; subMenuContainerEl.style.top = ''; }
+    if (subMenuContainerEl) { subMenuContainerEl.innerHTML = ''; subMenuContainerEl.style.display = 'none'; subMenuContainerEl.style.left = ''; subMenuContainerEl.style.top = ''; subMenuContainerEl.style.maxWidth = ''; subMenuContainerEl.style.overflowX = ''; }
     if (subSubMenuContainerEl) { subSubMenuContainerEl.innerHTML = ''; subSubMenuContainerEl.style.display = 'none'; subSubMenuContainerEl.style.left = ''; subSubMenuContainerEl.style.top = ''; }
     // Restore all master buttons visibility and remove pink state
     if (masterPanelEl) {
@@ -6491,14 +6491,18 @@ function openSubMenu(menuId, anchorEl) {
     if (subMenuContainerEl) {
         subMenuContainerEl.innerHTML = '';
         subMenuContainerEl.style.display = 'block';
-        // Position sub-menu items to the RIGHT of the clicked button
-        subMenuContainerEl.style.left = (anchorEl.offsetLeft + anchorEl.offsetWidth) + 'px';
+        const desiredLeft = anchorEl.offsetLeft + anchorEl.offsetWidth;
+        subMenuContainerEl.style.left = desiredLeft + 'px';
         subMenuContainerEl.style.top = '0';
-        // Which row the button is on
         const anchorRow = anchorEl.closest('.tb-row');
         const parentRowIdx = anchorRow ? Array.from(anchorRow.parentElement.children).indexOf(anchorRow) : 0;
-        // Render just the items (no parent button — the real one is still visible)
         buildSubMenuItems(menuSpec, menuId, subMenuContainerEl, parentRowIdx);
+        // Constrain width to viewport and enable horizontal scroll if needed
+        const menuRect = subMenuContainerEl.getBoundingClientRect();
+        if (menuRect.right > window.innerWidth - 4) {
+            subMenuContainerEl.style.maxWidth = (window.innerWidth - menuRect.left - 4) + 'px';
+            subMenuContainerEl.style.overflowX = 'auto';
+        }
     }
     refreshAllButtons();
 }

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -2852,6 +2852,57 @@ function updateTextBrightness() {
     }
 }
 
+function updateToolbarBorderColor() {
+    try {
+        // Toolbar border brightness: 0-1, where 1=white, 0=black
+        const borderFactor = tbState.bright.tbBrdr / 100;
+
+        // Create or update dynamic CSS for toolbar border
+        let styleEl = document.getElementById('dynamic-toolbar-border-color');
+        if (!styleEl) {
+            styleEl = document.createElement('style');
+            styleEl.id = 'dynamic-toolbar-border-color';
+            document.head.appendChild(styleEl);
+        }
+
+        // Interpolate border color from white (at 100) to black (at 0)
+        const borderColor = interpolateColor('#FFFFFF', borderFactor);
+
+        styleEl.textContent = `
+            #master-toolbar-container { border-bottom: 1px solid ${borderColor} !important; }
+        `;
+    } catch (e) {
+        // tbState not yet initialized
+    }
+}
+
+function updateCursorBrightness() {
+    try {
+        // Cursor brightness: 0-1, where 1=white, 0=black
+        const cursorFactor = tbState.bright.cursor / 100;
+
+        // Interpolate cursor stroke color from white (at 100) to black (at 0)
+        const cursorColor = interpolateColor('#FFFFFF', cursorFactor);
+
+        // Create dynamic CSS with updated cursor SVG
+        let styleEl = document.getElementById('dynamic-cursor-brightness');
+        if (!styleEl) {
+            styleEl = document.createElement('style');
+            styleEl.id = 'dynamic-cursor-brightness';
+            document.head.appendChild(styleEl);
+        }
+
+        // Generate new SVG cursor with interpolated color
+        const cursorSvg = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Cline x1='16' y1='9' x2='16' y2='12' stroke='${encodeURIComponent(cursorColor)}' stroke-width='4.5'/%3E%3Cline x1='16' y1='20' x2='16' y2='23' stroke='${encodeURIComponent(cursorColor)}' stroke-width='4.5'/%3E%3Cline x1='9' y1='16' x2='12' y2='16' stroke='${encodeURIComponent(cursorColor)}' stroke-width='4.5'/%3E%3Cline x1='20' y1='16' x2='23' y2='16' stroke='${encodeURIComponent(cursorColor)}' stroke-width='4.5'/%3E%3Crect x='12' y='12' width='8' height='8' fill='none' stroke='${encodeURIComponent(cursorColor)}' stroke-width='1.3'/%3E%3C/svg%3E") 16 16, crosshair`;
+
+        styleEl.textContent = `
+            :root { --eram-cursor: ${cursorSvg}; }
+        `;
+    } catch (e) {
+        // tbState not yet initialized
+    }
+}
+
 function interpolateColor(hexColor, factor) {
     // Parse hex color (e.g., #00CD00 -> [0, 205, 0])
     const r = parseInt(hexColor.slice(1, 3), 16);
@@ -2886,7 +2937,7 @@ function updateToolbarBrightness() {
             'tb-tan': '#DCA09B',
             'tb-teal': '#00C7D1',
             'tb-dark': '#000000',
-            'tb-toggle-grey-off': '#000000',
+            'tb-toggle-grey': '#000000',
             'tb-nosim': '#000066',
             'tb-toggle-on': '#0000D4',
             'tb-menu-open': '#DCA09B',
@@ -2898,6 +2949,9 @@ function updateToolbarBrightness() {
             const interpolated = interpolateColor(color, buttonFactor);
             css += `.tb-btn.${className} { background: ${interpolated} !important; }\n`;
         }
+
+        // Toggle grey ON state (light gray)
+        css += `.tb-btn.tb-toggle-grey.tb-toggle-on { background: ${interpolateColor('#C7C7C7', buttonFactor)} !important; }\n`;
 
         // Default button color
         css += `.tb-btn { background: ${interpolateColor('#0000D4', buttonFactor)} !important; }\n`;
@@ -5910,7 +5964,7 @@ const tbState = {
     openSubMenu: null,    // nested sub-menu id (e.g. 'weather' under 'atc-tools')
     // Brightness values (0-100) for buttons not yet wired
     bright: {
-        bckgrd: scopeBckgrd, cursor: 50, text: 100, prTgtr: 50, unpTgt: 50,
+        bckgrd: scopeBckgrd, cursor: 100, text: 100, prTgtr: 50, unpTgt: 50,
         prHist: 50, unpHist: 50, sldb: 50, bcklght: 90, button: 80,
         border: 50, toolbar: 50, tbBrdr: 50, fdb: 50, portal: 50,
         onFreq: 50, line4b: 50, dwell: 50, fence: 50,
@@ -6015,9 +6069,15 @@ const TB_MASTER = {
     id: 'master',
     rows: [
         [
-            nosim('DRAW'),
+            toggle('DRAW', {
+                isOn: () => false,
+                onToggle: () => {},
+            }),
             menu('ATC\nTOOLS', 'atc-tools'),
-            nosim('AB\nSETTING'),
+            toggle('AB\nSETTING', {
+                isOn: () => false,
+                onToggle: () => {},
+            }),
             incdec('RANGE', {
                 cls: 'tb-dark',
                 getValue: () => zoomToRange(map.getZoom()),
@@ -6050,7 +6110,10 @@ const TB_MASTER = {
         [
             menu('VIEWS', 'views'),
             menu('CHECK\nLISTS', 'check-lists'),
-            nosim('COMMAND\nMENUS'),
+            toggle('COMMAND\nMENUS', {
+                isOn: () => false,
+                onToggle: () => {},
+            }),
             menu('MAP', 'geomap'),
             incdec('ALT LIM', {
                 cls: 'tb-dark',
@@ -6064,7 +6127,10 @@ const TB_MASTER = {
                 onInc: () => {},
             }),
             menu('RADAR\nFILTER', 'radar-filter'),
-            nosim('PREFSET'),
+            toggle('PREFSET', {
+                isOn: () => false,
+                onToggle: () => {},
+            }),
             cmd('DELETE\nTEAROFF', {
                 cls: 'tb-teal',
                 onCmd: () => { closeAllSubMenus(); },
@@ -6081,8 +6147,16 @@ const TB_ATC_TOOLS = {
     id: 'atc-tools',
     rows: [
         [
-            { label: 'CRR FIX', type: 'toggle', nosim: true },
-            nosim('SPEED\nADVSRY'),
+            toggle('CRR FIX', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('SPEED\nADVSRY', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
             menu('WX', 'weather'),
         ],
     ],
@@ -6113,9 +6187,21 @@ const TB_WEATHER = {
             }),
         ],
         [
-            { label: 'WX1', type: 'nosim', cls: 'tb-dark' },
-            { label: 'WX2', type: 'nosim', cls: 'tb-dark' },
-            { label: 'WX3', type: 'nosim', cls: 'tb-dark' },
+            toggle('WX1', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('WX2', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('WX3', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
         ],
     ],
 };
@@ -6124,26 +6210,98 @@ const TB_VIEWS = {
     id: 'views',
     rows: [
         [
-            { label: 'ALTIM\nSET', type: 'toggle', nosim: true },
-            nosim('AUTO HO\nINHIB'),
-            nosim('CFR'),
-            { label: 'CODE', type: 'toggle', nosim: true },
-            nosim('CONFLCT\nALERT'),
-            nosim('CPDLC\nADV'),
-            nosim('CPDLC\nHIST'),
-            nosim('CPDLC\nTOC SET'),
-            { label: 'CRR', type: 'toggle', nosim: true },
+            toggle('ALTIM\nSET', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('AUTO HO\nINHIB', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CFR', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CODE', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CONFLCT\nALERT', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CPDLC\nADV', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CPDLC\nHIST', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CPDLC\nTOC SET', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CRR', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
         ],
         [
-            nosim('DEPT\nLIST'),
-            nosim('FLIGHT\nEVENT'),
-            nosim('GROUP\nSUP'),
-            nosim('HOLD\nLIST'),
-            nosim('INBND\nLIST'),
-            nosim('MRP\nLIST'),
-            nosim('SSA\nFILTER'),
-            nosim('UA'),
-            { label: 'WX\nREPORT', type: 'toggle', nosim: true },
+            toggle('DEPT\nLIST', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('FLIGHT\nEVENT', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('GROUP\nSUP', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('HOLD\nLIST', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('INBND\nLIST', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('MRP\nLIST', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('SSA\nFILTER', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('UA', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('WX\nREPORT', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
         ],
     ],
 };
@@ -6152,8 +6310,16 @@ const TB_CHECK_LISTS = {
     id: 'check-lists',
     rows: [
         [
-            { label: 'POS\nCHECK', type: 'toggle', nosim: true },
-            { label: 'EMERG\nCHECK', type: 'toggle', nosim: true },
+            toggle('POS\nCHECK', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('EMERG\nCHECK', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
         ],
     ],
 };
@@ -6162,15 +6328,27 @@ const TB_CURSOR = {
     id: 'cursor',
     rows: [
         [
-            nosim('SPEED'),
+            incdec('SPEED', {
+                cls: 'tb-green',
+                getValue: () => 0,
+                formatValue: v => v,
+                onDec: () => {},
+                onInc: () => {},
+            }),
             incdec('SIZE', {
-                nosim: true,
+                cls: 'tb-green',
                 getValue: () => tbState.cursorSize,
                 formatValue: v => String(v),
                 onDec: () => { tbState.cursorSize = Math.max(1, tbState.cursorSize - 1); },
                 onInc: () => { tbState.cursorSize = Math.min(5, tbState.cursorSize + 1); },
             }),
-            nosim('VOLUME'),
+            incdec('VOLUME', {
+                cls: 'tb-green',
+                getValue: () => 0,
+                formatValue: v => v,
+                onDec: () => {},
+                onInc: () => {},
+            }),
         ],
     ],
 };
@@ -6232,7 +6410,7 @@ const TB_BRIGHT = {
             menu('MAP\nBRIGHT', 'map-bright', { cls: 'tb-blue' }),
             nosim('CPDLC', { cls: 'tb-blue' }),
             incdec('BCKGRD', { cls: 'tb-green', getValue: () => tbState.bright.bckgrd, formatValue: v => v, onDec: () => { scopeBckgrd = Math.max(0, scopeBckgrd - 10); tbState.bright.bckgrd = scopeBckgrd; updateScopeBackground(); saveSettingsToLocalStorage(); }, onInc: () => { scopeBckgrd = Math.min(100, scopeBckgrd + 10); tbState.bright.bckgrd = scopeBckgrd; updateScopeBackground(); saveSettingsToLocalStorage(); } }),
-            incdec('CURSOR', { cls: 'tb-green', getValue: () => tbState.bright.cursor, formatValue: v => v, onDec: () => { tbState.bright.cursor = Math.max(0, tbState.bright.cursor - 10); }, onInc: () => { tbState.bright.cursor = Math.min(100, tbState.bright.cursor + 10); } }),
+            incdec('CURSOR', { cls: 'tb-green', getValue: () => tbState.bright.cursor, formatValue: v => v, onDec: () => { tbState.bright.cursor = Math.max(0, tbState.bright.cursor - 10); updateCursorBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.cursor = Math.min(100, tbState.bright.cursor + 10); updateCursorBrightness(); saveSettingsToLocalStorage(); } }),
             incdec('TEXT', { cls: 'tb-green', getValue: () => tbState.bright.text, formatValue: v => v, onDec: () => { tbState.bright.text = Math.max(0, tbState.bright.text - 10); updateTextBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.text = Math.min(100, tbState.bright.text + 10); updateTextBrightness(); saveSettingsToLocalStorage(); } }),
             incdec('PR TGT', { cls: 'tb-green', getValue: () => tbState.bright.prTgtr, formatValue: v => v, onDec: () => { tbState.bright.prTgtr = Math.max(0, tbState.bright.prTgtr - 10); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.prTgtr = Math.min(100, tbState.bright.prTgtr + 10); saveSettingsToLocalStorage(); } }),
             incdec('UNP TGT', { cls: 'tb-green', getValue: () => tbState.bright.unpTgt, formatValue: v => v, onDec: () => { tbState.bright.unpTgt = Math.max(0, tbState.bright.unpTgt - 10); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.unpTgt = Math.min(100, tbState.bright.unpTgt + 10); saveSettingsToLocalStorage(); } }),
@@ -6260,7 +6438,7 @@ const TB_BRIGHT = {
             incdec('BUTTON', { cls: 'tb-green', getValue: () => tbState.bright.button, formatValue: v => v, onDec: () => { tbState.bright.button = Math.max(0, tbState.bright.button - 10); updateButtonBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.button = Math.min(100, tbState.bright.button + 10); updateButtonBrightness(); saveSettingsToLocalStorage(); } }),
             incdec('BORDER', { cls: 'tb-green', getValue: () => tbState.bright.border, formatValue: v => v, onDec: () => { tbState.bright.border = Math.max(0, tbState.bright.border - 10); updateBorderBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.border = Math.min(100, tbState.bright.border + 10); updateBorderBrightness(); saveSettingsToLocalStorage(); } }),
             incdec('TOOLBAR', { cls: 'tb-green', getValue: () => tbState.bright.toolbar, formatValue: v => v, onDec: () => { tbState.bright.toolbar = Math.max(0, tbState.bright.toolbar - 10); updateToolbarBackgroundBrightness(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.toolbar = Math.min(100, tbState.bright.toolbar + 10); updateToolbarBackgroundBrightness(); saveSettingsToLocalStorage(); } }),
-            incdec('TB BRDR', { cls: 'tb-green', getValue: () => tbState.bright.tbBrdr, formatValue: v => v, onDec: () => { tbState.bright.tbBrdr = Math.max(0, tbState.bright.tbBrdr - 10); }, onInc: () => { tbState.bright.tbBrdr = Math.min(100, tbState.bright.tbBrdr + 10); } }),
+            incdec('TB BRDR', { cls: 'tb-green', getValue: () => tbState.bright.tbBrdr, formatValue: v => v, onDec: () => { tbState.bright.tbBrdr = Math.max(0, tbState.bright.tbBrdr - 10); updateToolbarBorderColor(); saveSettingsToLocalStorage(); }, onInc: () => { tbState.bright.tbBrdr = Math.min(100, tbState.bright.tbBrdr + 10); updateToolbarBorderColor(); saveSettingsToLocalStorage(); } }),
             nosim('AB BRDR'),
             incdec('FDB', { cls: 'tb-green', getValue: () => tbState.bright.fdb, formatValue: v => v, onDec: () => { tbState.bright.fdb = Math.max(0, tbState.bright.fdb - 10); }, onInc: () => { tbState.bright.fdb = Math.min(100, tbState.bright.fdb + 10); } }),
             incdec('PORTAL', { cls: 'tb-green', getValue: () => tbState.bright.portal, formatValue: v => v, onDec: () => { tbState.bright.portal = Math.max(0, tbState.bright.portal - 10); }, onInc: () => { tbState.bright.portal = Math.min(100, tbState.bright.portal + 10); } }),
@@ -6280,49 +6458,57 @@ const TB_MAP_BRIGHT = {
     parentMenu: 'bright',
     rows: [
         [
-            incdec('BCG 1', {
+            incdec('UHI', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-bnd-uhi'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-bnd-uhi', Math.max(0, getRangeVal('rng-bnd-uhi') - 10)),
                 onInc: () => setRangeVal('rng-bnd-uhi', Math.min(100, getRangeVal('rng-bnd-uhi') + 10)),
             }),
-            incdec('BCG 2', {
+            incdec('HI', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-bnd-hi'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-bnd-hi', Math.max(0, getRangeVal('rng-bnd-hi') - 10)),
                 onInc: () => setRangeVal('rng-bnd-hi', Math.min(100, getRangeVal('rng-bnd-hi') + 10)),
             }),
-            incdec('BCG 3', {
+            incdec('LO', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-bnd-lo'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-bnd-lo', Math.max(0, getRangeVal('rng-bnd-lo') - 10)),
                 onInc: () => setRangeVal('rng-bnd-lo', Math.min(100, getRangeVal('rng-bnd-lo') + 10)),
             }),
-            incdec('BCG 4', {
+            incdec('APP', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-bnd-app'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-bnd-app', Math.max(0, getRangeVal('rng-bnd-app') - 10)),
                 onInc: () => setRangeVal('rng-bnd-app', Math.min(100, getRangeVal('rng-bnd-app') + 10)),
             }),
-            incdec('BCG 5', {
+            incdec('HI AWY', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-jroutes'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-jroutes', Math.max(0, getRangeVal('rng-jroutes') - 10)),
                 onInc: () => setRangeVal('rng-jroutes', Math.min(100, getRangeVal('rng-jroutes') + 10)),
             }),
-            incdec('BCG 6', {
+            incdec('LO AWY', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-vroutes'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-vroutes', Math.max(0, getRangeVal('rng-vroutes') - 10)),
                 onInc: () => setRangeVal('rng-vroutes', Math.min(100, getRangeVal('rng-vroutes') + 10)),
             }),
-            incdec('BCG 7', {
+            incdec('VORS', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-vors'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-vors', Math.max(0, getRangeVal('rng-vors') - 10)),
                 onInc: () => setRangeVal('rng-vors', Math.min(100, getRangeVal('rng-vors') + 10)),
             }),
-            incdec('BCG 8', {
+            incdec('APTS', {
+                cls: 'tb-green',
                 getValue: () => getRangeVal('rng-airports'),
                 formatValue: v => v,
                 onDec: () => setRangeVal('rng-airports', Math.max(0, getRangeVal('rng-airports') - 10)),
@@ -6336,8 +6522,15 @@ const TB_FONT = {
     id: 'font',
     rows: [
         [
-            incdec('LINE 4', { nosim: true, getValue: () => 10, formatValue: v => v, onDec: () => {}, onInc: () => {} }),
+            incdec('LINE 4', {
+                cls: 'tb-green',
+                getValue: () => 10,
+                formatValue: v => v,
+                onDec: () => {},
+                onInc: () => {},
+            }),
             incdec('FDB', {
+                cls: 'tb-green',
                 getValue: () => parseInt(getSelectVal('sel-fontsize')),
                 formatValue: v => v,
                 onDec: () => {
@@ -6351,10 +6544,34 @@ const TB_FONT = {
                     if (idx < FONT_STEPS.length - 1) setSelectVal('sel-fontsize', FONT_STEPS[idx + 1]);
                 },
             }),
-            nosim('TOOLBAR'),
-            incdec('LDB', { nosim: true, getValue: () => 10, formatValue: v => v, onDec: () => {}, onInc: () => {} }),
-            incdec('RDB', { nosim: true, getValue: () => 10, formatValue: v => v, onDec: () => {}, onInc: () => {} }),
-            nosim('OUTAGE'),
+            incdec('TOOLBAR', {
+                cls: 'tb-green',
+                getValue: () => 10,
+                formatValue: v => v,
+                onDec: () => {},
+                onInc: () => {},
+            }),
+            incdec('LDB', {
+                cls: 'tb-green',
+                getValue: () => 10,
+                formatValue: v => v,
+                onDec: () => {},
+                onInc: () => {},
+            }),
+            incdec('RDB', {
+                cls: 'tb-green',
+                getValue: () => 10,
+                formatValue: v => v,
+                onDec: () => {},
+                onInc: () => {},
+            }),
+            incdec('OUTAGE', {
+                cls: 'tb-green',
+                getValue: () => 10,
+                formatValue: v => v,
+                onDec: () => {},
+                onInc: () => {},
+            }),
         ],
     ],
 };
@@ -6364,10 +6581,26 @@ const TB_DB_FIELDS = {
     id: 'db-fields',
     rows: [
         [
-            { label: 'NON-\nRVSM', type: 'toggle', nosim: true, isOn: () => true },
-            nosim('VRI'),
-            { label: 'CODE', type: 'toggle', nosim: true },
-            { label: 'SPEED', type: 'toggle', nosim: true },
+            toggle('NON-\nRVSM', {
+                cls: 'tb-toggle-grey',
+                isOn: () => true,
+                onToggle: () => {},
+            }),
+            toggle('VRI', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CODE', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('SPEED', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
             toggle('DEST', {
                 cls: 'tb-toggle-grey',
                 isOn: () => getSelectVal('sel-line4') === 'DEST',
@@ -6385,12 +6618,17 @@ const TB_DB_FIELDS = {
                 },
             }),
             incdec('FDB LDR', {
-                getValue: () => 1,  // default leader length
+                cls: 'tb-green',
+                getValue: () => 1,
                 formatValue: v => v,
                 onDec: () => {},
                 onInc: () => {},
             }),
-            { label: 'BCAST\nFLID', type: 'toggle', nosim: true },
+            toggle('BCAST\nFLID', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
             toggle('PORTAL\nFENCE', {
                 cls: 'tb-toggle-grey',
                 isOn: () => showPortalFence,
@@ -6398,14 +6636,48 @@ const TB_DB_FIELDS = {
             }),
         ],
         [
-            nosim('NON-\nADS-B'),
-            nosim('NONADSB'),
-            { label: 'SAT\nCOMM', type: 'toggle', nosim: true },
-            nosim('TFM\nREROUTE'),
-            { label: 'CRR\nRDB', type: 'toggle', nosim: true },
-            nosim('STA RDB'),
-            nosim('DELAY\nRDB'),
-            nosim('DELAY\nFORMAT'),
+            incdec('NON-\nADS-B', {
+                cls: 'tb-green',
+                getValue: () => 1,
+                formatValue: v => v,
+                onDec: () => {},
+                onInc: () => {},
+            }),
+            toggle('NONADSB', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('SAT\nCOMM', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('TFM\nREROUTE', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('CRR\nRDB', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('STA RDB', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('DELAY\nRDB', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('DELAY\nFORMAT', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
         ],
     ],
 };
@@ -6414,17 +6686,50 @@ const TB_RADAR_FILTER = {
     id: 'radar-filter',
     rows: [
         [
-            { label: 'ALL\nLDBS', type: 'toggle', nosim: true },
-            { label: 'PR LDB', type: 'toggle', nosim: true },
-            { label: 'UNP\nLDB', type: 'toggle', nosim: true },
-            { label: 'ALL\nPRIM', type: 'toggle', nosim: true },
-            { label: 'NON\nMODE C', type: 'toggle', nosim: true },
+            toggle('ALL\nLDBS', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('PR LDB', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('UNP\nLDB', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('ALL\nPRIM', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('NON\nMODE C', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
         ],
         [
-            { label: 'SELECT\nBEACON', type: 'toggle', nosim: true },
-            nosim('PERM\nECHO'),
-            nosim('STROBE\nLINES'),
+            toggle('SELECT\nBEACON', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('PERM\nECHO', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
+            toggle('STROBE\nLINES', {
+                cls: 'tb-toggle-grey',
+                isOn: () => false,
+                onToggle: () => {},
+            }),
             incdec('HISTORY', {
+                cls: 'tb-green',
                 getValue: () => parseInt(getSelectVal('sel-histcount')),
                 formatValue: v => v,
                 onDec: () => {
@@ -6527,7 +6832,10 @@ function createButton(spec, panelId, rowIdx, colIdx) {
         // Left click
         el.addEventListener('click', (e) => {
             e.stopPropagation();
-            handleBtnAction(spec, key, false);
+            // Ignore clicks on the tearoff strip
+            if (!e.target.closest('.tb-tear')) {
+                handleBtnAction(spec, key, false);
+            }
         });
 
         // Middle click via mousedown
@@ -6535,7 +6843,10 @@ function createButton(spec, panelId, rowIdx, colIdx) {
             if (e.button === 1) {
                 e.preventDefault();
                 e.stopPropagation();
-                handleBtnAction(spec, key, true);
+                // Ignore middle-clicks on the tearoff strip
+                if (!e.target.closest('.tb-tear')) {
+                    handleBtnAction(spec, key, true);
+                }
             }
         });
 
@@ -6961,6 +7272,8 @@ refreshAllButtons();  // Refresh button displays to show correct initial values
 updateBorderBrightness();  // Initialize border brightness
 updateToolbarBackgroundBrightness();  // Initialize toolbar background brightness
 updateTextBrightness();  // Initialize text brightness
+updateToolbarBorderColor();  // Initialize toolbar border color
+updateCursorBrightness();  // Initialize cursor brightness
 
 // Apply initial visibility from URL
 if (tbState.masterVisible) {

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -45,6 +45,8 @@ const ldrLenOverrides = new Map(); // gufi → leader length level (0-3), defaul
 const driActive = new Map();       // gufi → 'J' (standard 5nm) or 'T' (reduced 3nm)
 const dwellLocked = new Set();     // GUFIs with persistent dwell emphasis (toggled via Field A click)
 const vciActive = new Set();       // GUFIs with VCI (Visual Communications Indicator) toggled on
+let codeButtonPressed = false;     // momentary CODE button state — show squawk codes when true
+let speedButtonPressed = false;    // momentary SPEED button state — show speed instead of handoff when true
 const activeTearoffs = new Map();  // btnKey → { floatingEl, buttonClone } — toolbar tearoff state
 const activeFloatingMenus = new Map(); // btnKey → { floatingMenuEl, anchorEl } — floating menu state
 let tearoffDeleteMode = false;  // when true, left-click marks for deletion, middle-click deletes
@@ -1475,13 +1477,19 @@ function buildMarkerHtml(f, cls) {
     } else if (ldbBrightness > 0) {
         // VCI clears when track goes to LDB
         vciActive.delete(f.gufi);
-        // Limited Data Block (2 lines) — no leader line, right next to target
+        // Limited Data Block (2-3 lines) — no leader line, right next to target
         const ldbOp = ldbBrightness / 100;
         const l1 = f.callsign || '???';
         const alt = f.reportedAltitude ?? f.assignedAltitude;
         const l2 = alt != null ? String(Math.round(alt / 100)).padStart(3, '0') : '';
         const dbCls = isEmrg ? ' emrg' : '';
-        html += `<div class="ac-db ldb${dbCls}" style="left:${Math.ceil(CHAR_W)}px; top:${-LINE_H}px; opacity:${ldbOp};">${l1}\n${l2}</div>`;
+        // Add third line with squawk code when CODE button is pressed
+        let ldbContent = `${l1}\n${l2}`;
+        if (codeButtonPressed) {
+            const squawk = f.squawk ? String(f.squawk).padStart(4, '0') : '    ';
+            ldbContent += `\n${squawk}`;
+        }
+        html += `<div class="ac-db ldb${dbCls}" style="left:${Math.ceil(CHAR_W)}px; top:${-LINE_H}px; opacity:${ldbOp};">${ldbContent}</div>`;
     }
     // ldbBrightness === 0 for LDB → no data block at all
 
@@ -1733,6 +1741,12 @@ function formatLine3(f, cls) {
     // Normal Field E: single-letter destination + 3-digit groundspeed, or just groundspeed
     const gsStr = destLetter && gs ? `${cid}${destLetter}${gs}` : gs ? `${cid} ${gs}` : cid;
 
+    // ── CODE button: show squawk code when pressed ──
+    if (codeButtonPressed) {
+        const squawk = f.squawk ? String(f.squawk).padStart(4, '0') : '    ';
+        return `${cid}${squawk}`;
+    }
+
     // ── ERAM Field E priority (per specification) ──
 
     // 1. Special squawk codes (highest priority, static display)
@@ -1742,6 +1756,15 @@ function formatLine3(f, cls) {
     if (f.squawk === '1276') return `${cid} ADIZ`;
     if (f.squawk === '7400') return `${cid} LLNK`;
     if (f.squawk === '7777') return `${cid} AFIO`;
+
+    // 1.5 SPEED button: show speed instead of handoff when pressed
+    if (speedButtonPressed) {
+        const hoEvt = hoEventType(f.handoffEvent);
+        if (hoEvt && f.handoffReceiving) {
+            // Flight has active handoff and SPEED button is pressed — show speed
+            return gsStr;
+        }
+    }
 
     // 2. Active handoff — flash in Field E (uses global flashTime so ALL tracks sync)
     //    H = proposed, O = accepted/executing, K = forced acceptance (/OK)
@@ -6624,16 +6647,19 @@ const TB_DB_FIELDS = {
                 cls: 'tb-toggle-grey',
                 isOn: () => false,
                 onToggle: () => {},
+                isMomentary: true,
             }),
             toggle('CODE', {
                 cls: 'tb-toggle-grey',
                 isOn: () => false,
                 onToggle: () => {},
+                isMomentary: true,
             }),
             toggle('SPEED', {
                 cls: 'tb-toggle-grey',
                 isOn: () => false,
                 onToggle: () => {},
+                isMomentary: true,
             }),
             toggle('DEST', {
                 cls: 'tb-toggle-grey',
@@ -6852,7 +6878,35 @@ function createFloatingTearoff(btnKey, spec) {
             buttonClone.addEventListener('click', (e) => {
                 if (!e.target.closest('.tb-tear')) {
                     e.stopPropagation();
-                    // In delete mode, left-click marks tearoff for deletion
+                    // Skip normal toggle for momentary buttons (they only respond to hold, not click)
+                    if (!(spec.type === 'toggle' && spec.isMomentary)) {
+                        // In delete mode, left-click marks tearoff for deletion
+                        if (tearoffDeleteMode) {
+                            if (selectedTearoffsForDeletion.has(btnKey)) {
+                                selectedTearoffsForDeletion.delete(btnKey);
+                                buttonClone.classList.remove('tb-delete-selected');
+                            } else {
+                                selectedTearoffsForDeletion.add(btnKey);
+                                buttonClone.classList.add('tb-delete-selected');
+                            }
+                        } else {
+                            // For menu buttons, pass the buttonClone as the anchor so menu opens next to floating button
+                            handleBtnAction(spec, btnKey, false, spec.type === 'menu' ? buttonClone : undefined);
+                        }
+                    }
+                }
+            });
+
+            // Mousedown: handle momentary toggle and middle-click
+            buttonClone.addEventListener('mousedown', (e) => {
+                const isTearoff = e.target.closest('.tb-tear');
+
+                // Momentary toggle: left-click shows "on" state while held
+                if (e.button === 0 && !isTearoff && spec.type === 'toggle' && spec.isMomentary) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    // Check delete mode first (allow marking for deletion)
                     if (tearoffDeleteMode) {
                         if (selectedTearoffsForDeletion.has(btnKey)) {
                             selectedTearoffsForDeletion.delete(btnKey);
@@ -6861,16 +6915,24 @@ function createFloatingTearoff(btnKey, spec) {
                             selectedTearoffsForDeletion.add(btnKey);
                             buttonClone.classList.add('tb-delete-selected');
                         }
-                    } else {
-                        // For menu buttons, pass the buttonClone as the anchor so menu opens next to floating button
-                        handleBtnAction(spec, btnKey, false, spec.type === 'menu' ? buttonClone : undefined);
+                        return;
                     }
-                }
-            });
 
-            // Middle click (skip if on tearoff strip)
-            buttonClone.addEventListener('mousedown', (e) => {
-                if (e.button === 1 && !e.target.closest('.tb-tear')) {
+                    buttonClone.classList.add('tb-toggle-on');
+                    updateMomentaryIndicator(buttonClone, spec, true);
+                    // Track momentary button state
+                    if (spec.label === 'CODE') {
+                        codeButtonPressed = true;
+                        invalidateAllMarkers();
+                    } else if (spec.label === 'SPEED') {
+                        speedButtonPressed = true;
+                        invalidateAllMarkers();
+                    }
+                    return;
+                }
+
+                // Middle click
+                if (e.button === 1 && !isTearoff) {
                     e.preventDefault();
                     e.stopPropagation();
                     // Check if in delete mode and delete the floating tearoff
@@ -6894,6 +6956,39 @@ function createFloatingTearoff(btnKey, spec) {
                         console.log('Tearoffs deleted');
                     } else {
                         handleBtnAction(spec, btnKey, true, spec.type === 'menu' ? buttonClone : undefined);
+                    }
+                }
+            });
+
+            // Mouseup: revert momentary toggle to off state
+            buttonClone.addEventListener('mouseup', (e) => {
+                if (spec.type === 'toggle' && spec.isMomentary) {
+                    e.stopPropagation();
+                    buttonClone.classList.remove('tb-toggle-on');
+                    updateMomentaryIndicator(buttonClone, spec, false);
+                    // Track momentary button state
+                    if (spec.label === 'CODE') {
+                        codeButtonPressed = false;
+                        invalidateAllMarkers();
+                    } else if (spec.label === 'SPEED') {
+                        speedButtonPressed = false;
+                        invalidateAllMarkers();
+                    }
+                }
+            });
+
+            // Mouseleave: revert momentary toggle if mouse leaves button while held
+            buttonClone.addEventListener('mouseleave', (e) => {
+                if (spec.type === 'toggle' && spec.isMomentary) {
+                    buttonClone.classList.remove('tb-toggle-on');
+                    updateMomentaryIndicator(buttonClone, spec, false);
+                    // Track momentary button state
+                    if (spec.label === 'CODE') {
+                        codeButtonPressed = false;
+                        invalidateAllMarkers();
+                    } else if (spec.label === 'SPEED') {
+                        speedButtonPressed = false;
+                        invalidateAllMarkers();
                     }
                 }
             });
@@ -7066,6 +7161,19 @@ function updateFloatingMenuButton(clickedEl, spec) {
     }
 }
 
+function updateMomentaryIndicator(el, spec, isPressed) {
+    const ind = el.querySelector('.tb-momentary-ind');
+    if (!ind) return;
+
+    // For momentary buttons, determine color based on whether button is currently pressed
+    // When pressed (isPressed=true): button is ON (gray), so show BLACK triangle
+    // When not pressed (isPressed=false): button is OFF (black), so show GRAY triangle
+    const triangleColor = isPressed ? '#000000' : '#C7C7C7';
+
+    // Set triangle color
+    ind.style.color = triangleColor;
+}
+
 function createButton(spec, panelId, rowIdx, colIdx) {
     const el = document.createElement('div');
     el.className = 'tb-btn';
@@ -7109,6 +7217,15 @@ function createButton(spec, panelId, rowIdx, colIdx) {
         content.appendChild(ind);
     }
 
+    // Momentary toggle indicator triangle
+    if (spec.type === 'toggle' && spec.isMomentary) {
+        const momInd = document.createElement('div');
+        momInd.className = 'tb-momentary-ind';
+        momInd.textContent = '◀';
+        el.appendChild(momInd);
+        updateMomentaryIndicator(el, spec, false);
+    }
+
     el.appendChild(content);
 
     // Toggle state
@@ -7129,34 +7246,70 @@ function createButton(spec, panelId, rowIdx, colIdx) {
             e.stopPropagation();
             // Ignore clicks on the tearoff strip
             if (!e.target.closest('.tb-tear')) {
-                // For menu buttons in floating menus, pass the button element as anchor
-                const isInFloatingMenu = el.closest('.tb-floating-menu');
-                const anchorForMenu = (spec.type === 'menu' && isInFloatingMenu) ? el : undefined;
-                handleBtnAction(spec, key, false, anchorForMenu);
-                // Update this button's visual state immediately (for menu buttons and floating menu buttons)
-                if (spec.type === 'toggle' && spec.isOn) {
-                    const shouldBeOn = spec.isOn();
-                    el.classList.toggle('tb-toggle-on', shouldBeOn);
-                    // Also update floating menu button if in a floating menu
-                    updateFloatingMenuButton(el, spec);
-                } else if (spec.type === 'incdec' && spec.getValue) {
-                    const valDiv = el.querySelector('.tb-value');
-                    if (valDiv) {
-                        valDiv.textContent = spec.formatValue(spec.getValue());
+                // Skip normal toggle for momentary buttons (they only respond to hold, not click)
+                if (!(spec.type === 'toggle' && spec.isMomentary)) {
+                    // For menu buttons in floating menus, pass the button element as anchor
+                    const isInFloatingMenu = el.closest('.tb-floating-menu');
+                    const anchorForMenu = (spec.type === 'menu' && isInFloatingMenu) ? el : undefined;
+                    handleBtnAction(spec, key, false, anchorForMenu);
+                    // Update this button's visual state immediately (for menu buttons and floating menu buttons)
+                    if (spec.type === 'toggle' && spec.isOn) {
+                        const shouldBeOn = spec.isOn();
+                        el.classList.toggle('tb-toggle-on', shouldBeOn);
+                        // Also update floating menu button if in a floating menu
+                        updateFloatingMenuButton(el, spec);
+                    } else if (spec.type === 'incdec' && spec.getValue) {
+                        const valDiv = el.querySelector('.tb-value');
+                        if (valDiv) {
+                            valDiv.textContent = spec.formatValue(spec.getValue());
+                        }
+                        // Also update floating menu button if in a floating menu
+                        updateFloatingMenuButton(el, spec);
                     }
-                    // Also update floating menu button if in a floating menu
-                    updateFloatingMenuButton(el, spec);
                 }
             }
         });
 
-        // Middle click via mousedown
+        // Mousedown: handle momentary toggle and middle-click
         el.addEventListener('mousedown', (e) => {
+            const isTearoff = e.target.closest('.tb-tear');
+
+            // Momentary toggle: left-click shows "on" state while held
+            if (e.button === 0 && !isTearoff && spec.type === 'toggle' && spec.isMomentary) {
+                e.preventDefault();
+                e.stopPropagation();
+
+                // Check delete mode first (allow marking for deletion)
+                if (tearoffDeleteMode) {
+                    if (selectedTearoffsForDeletion.has(key)) {
+                        selectedTearoffsForDeletion.delete(key);
+                        el.classList.remove('tb-delete-selected');
+                    } else {
+                        selectedTearoffsForDeletion.add(key);
+                        el.classList.add('tb-delete-selected');
+                    }
+                    return;
+                }
+
+                el.classList.add('tb-toggle-on');
+                updateMomentaryIndicator(el, spec, true);
+                // Track momentary button state
+                if (spec.label === 'CODE') {
+                    codeButtonPressed = true;
+                    invalidateAllMarkers();
+                } else if (spec.label === 'SPEED') {
+                    speedButtonPressed = true;
+                    invalidateAllMarkers();
+                }
+                return;
+            }
+
+            // Middle click
             if (e.button === 1) {
                 e.preventDefault();
                 e.stopPropagation();
                 // Ignore middle-clicks on the tearoff strip
-                if (!e.target.closest('.tb-tear')) {
+                if (!isTearoff) {
                     handleBtnAction(spec, key, true);
                     // Update this button's visual state immediately
                     if (spec.type === 'incdec' && spec.getValue) {
@@ -7167,6 +7320,39 @@ function createButton(spec, panelId, rowIdx, colIdx) {
                         // Also update floating menu button if in a floating menu
                         updateFloatingMenuButton(el, spec);
                     }
+                }
+            }
+        });
+
+        // Mouseup: revert momentary toggle to off state
+        el.addEventListener('mouseup', (e) => {
+            if (spec.type === 'toggle' && spec.isMomentary) {
+                e.stopPropagation();
+                el.classList.remove('tb-toggle-on');
+                updateMomentaryIndicator(el, spec, false);
+                // Track momentary button state
+                if (spec.label === 'CODE') {
+                    codeButtonPressed = false;
+                    invalidateAllMarkers();
+                } else if (spec.label === 'SPEED') {
+                    speedButtonPressed = false;
+                    invalidateAllMarkers();
+                }
+            }
+        });
+
+        // Mouseleave: revert momentary toggle if mouse leaves button while held
+        el.addEventListener('mouseleave', (e) => {
+            if (spec.type === 'toggle' && spec.isMomentary) {
+                el.classList.remove('tb-toggle-on');
+                updateMomentaryIndicator(el, spec, false);
+                // Track momentary button state
+                if (spec.label === 'CODE') {
+                    codeButtonPressed = false;
+                    invalidateAllMarkers();
+                } else if (spec.label === 'SPEED') {
+                    speedButtonPressed = false;
+                    invalidateAllMarkers();
                 }
             }
         });
@@ -7224,6 +7410,10 @@ function refreshButton(key) {
     // Update toggle state
     if (spec.type === 'toggle' && !isNosim && spec.isOn) {
         el.classList.toggle('tb-toggle-on', spec.isOn());
+        // Update momentary indicator if it's a momentary button (only if not currently pressed)
+        if (spec.isMomentary && !el.classList.contains('tb-toggle-on')) {
+            updateMomentaryIndicator(el, spec, false);
+        }
     }
 
     // Update menu-open state

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -3559,7 +3559,11 @@ setInterval(() => { if (selectedGufi) showFlightDetail(selectedGufi); }, 5000);
 function loadSettingsFromLocalStorage() {
     try {
         const saved = localStorage.getItem('eram-settings');
-        if (!saved) return; // Use defaults if no saved settings
+        if (!saved) {
+            // No saved settings, but still need to apply rendering with defaults
+            updateScopeBackground();
+            return;
+        }
 
         const settings = JSON.parse(saved);
 
@@ -3585,6 +3589,10 @@ function loadSettingsFromLocalStorage() {
         if (settings.scopeBckgrd !== undefined) scopeBckgrd = settings.scopeBckgrd;
         if (settings.scopeBcklght !== undefined) scopeBcklght = settings.scopeBcklght;
         if (settings.tbVisible !== undefined) window._tbVisible = settings.tbVisible;
+
+        // Sync button state with restored global variables
+        tbState.bright.bckgrd = scopeBckgrd;
+        tbState.bright.bcklght = scopeBcklght;
 
         // Restore map position/zoom
         if (settings.mapCenter && settings.mapZoom !== undefined) {
@@ -6007,8 +6015,8 @@ const tbState = {
     openSubMenu: null,    // nested sub-menu id (e.g. 'weather' under 'atc-tools')
     // Brightness values (0-100) for buttons not yet wired
     bright: {
-        bckgrd: 40, cursor: 100, text: 100, prTgtr: 50, unpTgt: 50,
-        prHist: 50, unpHist: 50, sldb: 50, bcklght: 80, button: 70,
+        bckgrd: 50, cursor: 100, text: 100, prTgtr: 50, unpTgt: 50,
+        prHist: 50, unpHist: 50, sldb: 50, bcklght: 90, button: 70,
         border: 30, toolbar: 30, tbBrdr: 30, fdb: 50, portal: 50,
         onFreq: 50, line4b: 50, dwell: 50, fence: 50,
     },

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -2787,6 +2787,12 @@ function updateScopeBackground() {
         toolbarPanel.style.filter = `brightness(${backlightFactor})`;
     }
 
+    // Apply backlight to tearoff button (visibility toggle)
+    const tearoffContainer = document.getElementById('tb-tearoff');
+    if (tearoffContainer) {
+        tearoffContainer.style.filter = `brightness(${backlightFactor})`;
+    }
+
     // Update floating tearoff colors with backlight (floating menus inherit this since they're children)
     for (const [, tearoff] of activeTearoffs) {
         if (tearoff.floatingEl) {
@@ -2880,6 +2886,7 @@ function updateTextBrightness() {
             .tb-btn .tb-label { color: ${textColor} !important; }
             .tb-btn .tb-value { color: ${textColor} !important; }
             .tb-btn .tb-menu-ind { color: ${textColor} !important; }
+            #tb-tearoff-btn .tb-tearoff-label { color: ${textColor} !important; }
         `;
     } catch (e) {
         // tbState not yet initialized
@@ -3003,6 +3010,15 @@ function updateToolbarBrightness() {
         // Disabled tearoff strip color (interpolate grey toward black with backlight)
         const disabledTearoffColor = interpolateColor('#C7C7C7', combinedFactor);
         css += `.tb-btn .tb-tear.tb-tear-disabled { background: ${disabledTearoffColor} !important; }\n`;
+
+        // Toolbar toggle button (#tb-tearoff-btn) — green button that shows/hides the toolbar
+        const tearoffBtnColor = interpolateColor('#00CD00', buttonFactor);
+        css += `#tb-tearoff-btn { background: ${tearoffBtnColor} !important; }\n`;
+        css += `#tb-tearoff-btn:hover { background: ${tearoffBtnColor} !important; }\n`;
+
+        // Toolbar toggle button gold strip (affected by backlight like button tearoff strips)
+        const tearoffBtnGoldColor = interpolateColor('#FFFFA1', combinedFactor);
+        css += `#tb-tearoff-btn .tb-gold-strip { background: ${tearoffBtnGoldColor} !important; }\n`;
 
         styleEl.textContent = css;
     } catch (e) {

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -2817,6 +2817,9 @@ function updateToolbarBackgroundBrightness() {
             #master-toolbar-container { background-color: ${toolbarBgColor} !important; }
             .tb-master-grid { background-color: ${toolbarBgColor} !important; }
             .tb-submenu { background-color: ${toolbarBgColor} !important; }
+            .tb-side-bar { background-color: ${toolbarBgColor} !important; }
+            .tb-side-bar .tb-arrow-btn { background-color: ${toolbarBgColor} !important; }
+            .tb-side-bar .tb-arrow-btn:hover { background-color: ${interpolateColor('#D3D3D3', toolbarFactor)} !important; }
         `;
     } catch (e) {
         // tbState not yet initialized
@@ -6612,16 +6615,58 @@ function refreshAllSubMenus() {
 // CRC behavior: when a menu opens, the master toolbar disappears and is replaced
 // by a new toolbar: [pink parent button] + [sub-menu items extending right]
 
+function cleanupMenuScrolling(containerEl) {
+    if (!containerEl) return;
+    if (containerEl._wheelHandler) { containerEl.removeEventListener('wheel', containerEl._wheelHandler); delete containerEl._wheelHandler; }
+    if (containerEl._dragDown) { containerEl.removeEventListener('mousedown', containerEl._dragDown); window.removeEventListener('mousemove', containerEl._dragMove); window.removeEventListener('mouseup', containerEl._dragUp); delete containerEl._dragDown; delete containerEl._dragMove; delete containerEl._dragUp; }
+    containerEl.style.cursor = '';
+}
+
+function setupMenuScrolling(containerEl) {
+    if (!containerEl) return;
+    cleanupMenuScrolling(containerEl);
+    // Check if menu needs scrolling
+    const menuRect = containerEl.getBoundingClientRect();
+    if (menuRect.right > window.innerWidth - 4) {
+        containerEl.style.maxWidth = (window.innerWidth - menuRect.left - 4) + 'px';
+        containerEl.style.overflowX = 'auto';
+        containerEl._wheelHandler = (e) => {
+            if (e.deltaY !== 0) { e.preventDefault(); containerEl.scrollLeft += e.deltaY; }
+        };
+        containerEl.addEventListener('wheel', containerEl._wheelHandler, { passive: false });
+        // Drag-to-scroll
+        let _dragX = null, _dragScroll = 0;
+        containerEl._dragDown = (e) => {
+            if (e.button !== 0) return;
+            _dragX = e.clientX; _dragScroll = containerEl.scrollLeft;
+            containerEl.style.cursor = 'grabbing';
+            e.preventDefault();
+        };
+        containerEl._dragMove = (e) => {
+            if (_dragX === null) return;
+            containerEl.scrollLeft = _dragScroll - (e.clientX - _dragX);
+        };
+        containerEl._dragUp = () => {
+            _dragX = null; containerEl.style.cursor = 'grab';
+        };
+        containerEl.style.cursor = 'grab';
+        containerEl.addEventListener('mousedown', containerEl._dragDown);
+        window.addEventListener('mousemove', containerEl._dragMove);
+        window.addEventListener('mouseup', containerEl._dragUp);
+    }
+}
+
 function closeAllSubMenus() {
     tbState.openMenu = null;
     tbState.openSubMenu = null;
     if (subMenuContainerEl) {
-        if (subMenuContainerEl._wheelHandler) { subMenuContainerEl.removeEventListener('wheel', subMenuContainerEl._wheelHandler); delete subMenuContainerEl._wheelHandler; }
-        if (subMenuContainerEl._dragDown) { subMenuContainerEl.removeEventListener('mousedown', subMenuContainerEl._dragDown); window.removeEventListener('mousemove', subMenuContainerEl._dragMove); window.removeEventListener('mouseup', subMenuContainerEl._dragUp); delete subMenuContainerEl._dragDown; delete subMenuContainerEl._dragMove; delete subMenuContainerEl._dragUp; }
-        subMenuContainerEl.style.cursor = '';
+        cleanupMenuScrolling(subMenuContainerEl);
         subMenuContainerEl.innerHTML = ''; subMenuContainerEl.style.display = 'none'; subMenuContainerEl.style.left = ''; subMenuContainerEl.style.top = ''; subMenuContainerEl.style.maxWidth = ''; subMenuContainerEl.style.overflowX = ''; subMenuContainerEl.scrollLeft = 0;
     }
-    if (subSubMenuContainerEl) { subSubMenuContainerEl.innerHTML = ''; subSubMenuContainerEl.style.display = 'none'; subSubMenuContainerEl.style.left = ''; subSubMenuContainerEl.style.top = ''; }
+    if (subSubMenuContainerEl) {
+        cleanupMenuScrolling(subSubMenuContainerEl);
+        subSubMenuContainerEl.innerHTML = ''; subSubMenuContainerEl.style.display = 'none'; subSubMenuContainerEl.style.left = ''; subSubMenuContainerEl.style.top = ''; subSubMenuContainerEl.style.maxWidth = ''; subSubMenuContainerEl.style.overflowX = ''; subSubMenuContainerEl.scrollLeft = 0;
+    }
     // Restore all master buttons visibility and remove pink state
     if (masterPanelEl) {
         masterPanelEl.querySelectorAll('.tb-btn').forEach(btn => {
@@ -6640,20 +6685,30 @@ function openSubMenu(menuId, anchorEl) {
         // Nested sub-menu (e.g. weather under atc-tools, map-bright under bright)
         if (tbState.openSubMenu === menuId) {
             tbState.openSubMenu = null;
-            if (subSubMenuContainerEl) { subSubMenuContainerEl.innerHTML = ''; subSubMenuContainerEl.style.display = 'none'; }
+            if (subSubMenuContainerEl) {
+                cleanupMenuScrolling(subSubMenuContainerEl);
+                subSubMenuContainerEl.innerHTML = ''; subSubMenuContainerEl.style.display = 'none';
+                subSubMenuContainerEl.style.maxWidth = ''; subSubMenuContainerEl.style.overflowX = ''; subSubMenuContainerEl.scrollLeft = 0;
+            }
             refreshAllButtons();
             return;
         }
         tbState.openSubMenu = menuId;
         if (subSubMenuContainerEl) {
+            cleanupMenuScrolling(subSubMenuContainerEl);
             subSubMenuContainerEl.innerHTML = '';
             subSubMenuContainerEl.style.display = 'block';
+            subSubMenuContainerEl.style.maxWidth = '';
+            subSubMenuContainerEl.style.overflowX = '';
+            subSubMenuContainerEl.scrollLeft = 0;
             // Position at nested button's left edge within masterGrid
             const gridRect = subSubMenuContainerEl.parentElement.getBoundingClientRect();
             const anchorRect = anchorEl.getBoundingClientRect();
             subSubMenuContainerEl.style.left = (anchorRect.left - gridRect.left) + 'px';
             subSubMenuContainerEl.style.top = '0';
             buildInlineSubMenu(menuSpec, menuId, subSubMenuContainerEl);
+            // Setup scrolling for nested submenu (was missing before)
+            setupMenuScrolling(subSubMenuContainerEl);
         }
         refreshAllButtons();
         return;
@@ -6669,7 +6724,10 @@ function openSubMenu(menuId, anchorEl) {
     // sub-menu items extend to the right of the clicked button.
     tbState.openMenu = menuId;
     tbState.openSubMenu = null;
-    if (subSubMenuContainerEl) { subSubMenuContainerEl.innerHTML = ''; subSubMenuContainerEl.style.display = 'none'; subSubMenuContainerEl.style.left = ''; }
+    if (subSubMenuContainerEl) {
+        cleanupMenuScrolling(subSubMenuContainerEl);
+        subSubMenuContainerEl.innerHTML = ''; subSubMenuContainerEl.style.display = 'none'; subSubMenuContainerEl.style.left = '';
+    }
 
     // Hide all master buttons except the clicked one (it stays in place, turns pink)
     masterPanelEl.querySelectorAll('.tb-btn').forEach(btn => {
@@ -6689,35 +6747,8 @@ function openSubMenu(menuId, anchorEl) {
         const anchorRow = anchorEl.closest('.tb-row');
         const parentRowIdx = anchorRow ? Array.from(anchorRow.parentElement.children).indexOf(anchorRow) : 0;
         buildSubMenuItems(menuSpec, menuId, subMenuContainerEl, parentRowIdx);
-        // Constrain width to viewport and enable horizontal scroll if needed
-        const menuRect = subMenuContainerEl.getBoundingClientRect();
-        if (menuRect.right > window.innerWidth - 4) {
-            subMenuContainerEl.style.maxWidth = (window.innerWidth - menuRect.left - 4) + 'px';
-            subMenuContainerEl.style.overflowX = 'auto';
-            subMenuContainerEl._wheelHandler = (e) => {
-                if (e.deltaY !== 0) { e.preventDefault(); subMenuContainerEl.scrollLeft += e.deltaY; }
-            };
-            subMenuContainerEl.addEventListener('wheel', subMenuContainerEl._wheelHandler, { passive: false });
-            // Drag-to-scroll
-            let _dragX = null, _dragScroll = 0;
-            subMenuContainerEl._dragDown = (e) => {
-                if (e.button !== 0) return;
-                _dragX = e.clientX; _dragScroll = subMenuContainerEl.scrollLeft;
-                subMenuContainerEl.style.cursor = 'grabbing';
-                e.preventDefault();
-            };
-            subMenuContainerEl._dragMove = (e) => {
-                if (_dragX === null) return;
-                subMenuContainerEl.scrollLeft = _dragScroll - (e.clientX - _dragX);
-            };
-            subMenuContainerEl._dragUp = () => {
-                _dragX = null; subMenuContainerEl.style.cursor = 'grab';
-            };
-            subMenuContainerEl.style.cursor = 'grab';
-            subMenuContainerEl.addEventListener('mousedown', subMenuContainerEl._dragDown);
-            window.addEventListener('mousemove', subMenuContainerEl._dragMove);
-            window.addEventListener('mouseup', subMenuContainerEl._dragUp);
-        }
+        // Setup scrolling for top-level submenu
+        setupMenuScrolling(subMenuContainerEl);
     }
     refreshAllButtons();
 }

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -5425,14 +5425,12 @@ document.addEventListener('mousedown', e => {
 
 // Re-clamp on window resize
 window.addEventListener('resize', () => {
-    clampBox(document.getElementById('mca-ra-stack'));
     const poMenu = document.getElementById('po-menu');
     if (poMenu.style.display !== 'none') clampBox(poMenu);
     clampBox(document.getElementById('time-view'));
     const fm = document.getElementById('field-menu');
     if (fm.style.display !== 'none') clampBox(fm);
-    const mtb = document.getElementById('master-toolbar-container');
-    if (mtb && mtb.classList.contains('tb-visible')) clampBox(mtb);
+    // Skip mca-ra-stack to prevent shifting its bottom/right positioned element
 });
 
 setupBoxDrag(document.getElementById('mca-ra-stack'));

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -45,6 +45,10 @@ const ldrLenOverrides = new Map(); // gufi → leader length level (0-3), defaul
 const driActive = new Map();       // gufi → 'J' (standard 5nm) or 'T' (reduced 3nm)
 const dwellLocked = new Set();     // GUFIs with persistent dwell emphasis (toggled via Field A click)
 const vciActive = new Set();       // GUFIs with VCI (Visual Communications Indicator) toggled on
+const activeTearoffs = new Map();  // btnKey → { floatingEl, buttonClone } — toolbar tearoff state
+const activeFloatingMenus = new Map(); // btnKey → { floatingMenuEl, anchorEl } — floating menu state
+let tearoffDeleteMode = false;  // when true, left-click marks for deletion, middle-click deletes
+const selectedTearoffsForDeletion = new Set();  // btnKey → marked for deletion
 
 // Controller-entered altitude overrides (QZ/QQ/QR commands)
 // Local wins when present; SWIM clears local override only when it sends a genuinely NEW different value
@@ -2753,11 +2757,18 @@ function updateScopeBackground() {
     const lc = document.querySelector('.leaflet-container');
     if (lc) lc.style.setProperty('background', color, 'important');
 
-    // Apply backlight to toolbar
+    // Apply backlight to toolbar and floating tearoffs
+    const backlightFactor = 0.6 + (l * 0.5);
     const toolbarPanel = document.getElementById('master-toolbar-container');
     if (toolbarPanel) {
-        const backlightFactor = 0.6 + (l * 0.5);
         toolbarPanel.style.filter = `brightness(${backlightFactor})`;
+    }
+
+    // Update floating tearoff colors with backlight (floating menus inherit this since they're children)
+    for (const [, tearoff] of activeTearoffs) {
+        if (tearoff.floatingEl) {
+            tearoff.floatingEl.style.filter = `brightness(${backlightFactor})`;
+        }
     }
 
     updateToolbarBrightness();
@@ -2922,6 +2933,12 @@ function updateToolbarBrightness() {
         // Button brightness: 0-1, where 1=full color, 0=black
         const buttonFactor = tbState.bright.button / 100;
 
+        // Backlight factor: 0.6-1.0 range (affects tearoff color for floating buttons)
+        const backlightFactor = 0.6 + ((scopeBcklght / 100) * 0.5);
+
+        // Combined factor for floating tearoff colors
+        const combinedFactor = buttonFactor * backlightFactor;
+
         // Create or update dynamic CSS for button backgrounds
         let styleEl = document.getElementById('dynamic-button-brightness');
         if (!styleEl) {
@@ -2956,8 +2973,13 @@ function updateToolbarBrightness() {
         // Default button color
         css += `.tb-btn { background: ${interpolateColor('#0000D4', buttonFactor)} !important; }\n`;
 
-        // Tearoff strip color (interpolate toward black)
-        css += `.tb-btn .tb-tear { background: ${interpolateColor('#FFFFA1', buttonFactor)} !important; }\n`;
+        // Tearoff strip color (interpolate toward black with backlight)
+        const tearoffColor = interpolateColor('#FFFFA1', combinedFactor);
+        css += `.tb-btn .tb-tear { background: ${tearoffColor} !important; }\n`;
+
+        // Disabled tearoff strip color (interpolate grey toward black with backlight)
+        const disabledTearoffColor = interpolateColor('#C7C7C7', combinedFactor);
+        css += `.tb-btn .tb-tear.tb-tear-disabled { background: ${disabledTearoffColor} !important; }\n`;
 
         styleEl.textContent = css;
     } catch (e) {
@@ -5964,9 +5986,9 @@ const tbState = {
     openSubMenu: null,    // nested sub-menu id (e.g. 'weather' under 'atc-tools')
     // Brightness values (0-100) for buttons not yet wired
     bright: {
-        bckgrd: scopeBckgrd, cursor: 100, text: 100, prTgtr: 50, unpTgt: 50,
-        prHist: 50, unpHist: 50, sldb: 50, bcklght: 90, button: 80,
-        border: 50, toolbar: 50, tbBrdr: 50, fdb: 50, portal: 50,
+        bckgrd: 40, cursor: 100, text: 100, prTgtr: 50, unpTgt: 50,
+        prHist: 50, unpHist: 50, sldb: 50, bcklght: 80, button: 70,
+        border: 30, toolbar: 30, tbBrdr: 30, fdb: 50, portal: 50,
         onFreq: 50, line4b: 50, dwell: 50, fence: 50,
     },
     // Cursor sub-menu
@@ -6133,7 +6155,21 @@ const TB_MASTER = {
             }),
             cmd('DELETE\nTEAROFF', {
                 cls: 'tb-teal',
-                onCmd: () => { closeAllSubMenus(); },
+                onCmd: () => {
+                    // If exiting delete mode, clear any marked selections
+                    if (tearoffDeleteMode) {
+                        for (const key of selectedTearoffsForDeletion) {
+                            const tearoff = activeTearoffs.get(key);
+                            if (tearoff && tearoff.buttonClone) {
+                                tearoff.buttonClone.classList.remove('tb-delete-selected');
+                            }
+                        }
+                        selectedTearoffsForDeletion.clear();
+                    }
+                    tearoffDeleteMode = !tearoffDeleteMode;
+                    closeAllSubMenus();
+                    refreshAllButtons();
+                },
             }),
         ],
     ],
@@ -6774,6 +6810,264 @@ function btnKey(panelId, rowIdx, colIdx) {
     return panelId + ':' + rowIdx + ':' + colIdx;
 }
 
+function updateTearoffColors() {
+    // Update all tearoff strips: tan if no active tearoff, grey if one exists for this button
+    for (const [key, entry] of tbElements) {
+        const tear = entry.el.querySelector('.tb-tear');
+        if (!tear) continue;
+
+        const hasActiveTearoff = activeTearoffs.has(key);
+
+        if (hasActiveTearoff) {
+            // Grey (#C7C7C7) + disabled
+            tear.classList.add('tb-tear-disabled');
+            tear.style.cursor = 'default';
+            tear.dataset.disabled = 'true';
+        } else {
+            // Tan (#FFFFA1) + enabled
+            tear.classList.remove('tb-tear-disabled');
+            tear.style.cursor = 'var(--eram-cursor)';
+            tear.dataset.disabled = 'false';
+        }
+    }
+}
+
+function createFloatingTearoff(btnKey, spec) {
+    // Create floating container (just wraps the button)
+    const container = document.createElement('div');
+    container.className = 'tb-floating-tearoff';
+    container.style.cssText = `
+        position: fixed;
+        z-index: 970;
+        user-select: none;
+    `;
+
+    // Clone the button
+    let buttonClone = null;
+    const sourceEntry = tbElements.get(btnKey);
+    if (sourceEntry) {
+        buttonClone = sourceEntry.el.cloneNode(true);
+
+        // Re-attach event listeners to the clone
+        if (!spec.nosim && spec.type !== 'nosim') {
+            // Left click (skip if on tearoff strip)
+            buttonClone.addEventListener('click', (e) => {
+                if (!e.target.closest('.tb-tear')) {
+                    e.stopPropagation();
+                    // In delete mode, left-click marks tearoff for deletion
+                    if (tearoffDeleteMode) {
+                        if (selectedTearoffsForDeletion.has(btnKey)) {
+                            selectedTearoffsForDeletion.delete(btnKey);
+                            buttonClone.classList.remove('tb-delete-selected');
+                        } else {
+                            selectedTearoffsForDeletion.add(btnKey);
+                            buttonClone.classList.add('tb-delete-selected');
+                        }
+                    } else {
+                        // For menu buttons, pass the buttonClone as the anchor so menu opens next to floating button
+                        handleBtnAction(spec, btnKey, false, spec.type === 'menu' ? buttonClone : undefined);
+                    }
+                }
+            });
+
+            // Middle click (skip if on tearoff strip)
+            buttonClone.addEventListener('mousedown', (e) => {
+                if (e.button === 1 && !e.target.closest('.tb-tear')) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    // Check if in delete mode and delete the floating tearoff
+                    if (tearoffDeleteMode) {
+                        // Delete the middle-clicked tearoff plus all selected ones
+                        selectedTearoffsForDeletion.add(btnKey);
+
+                        for (const key of selectedTearoffsForDeletion) {
+                            const tearoff = activeTearoffs.get(key);
+                            if (tearoff) {
+                                tearoff.floatingEl.remove();
+                                activeTearoffs.delete(key);
+                            }
+                        }
+
+                        selectedTearoffsForDeletion.clear();
+                        updateTearoffColors();
+                        // Turn off delete mode after deleting
+                        tearoffDeleteMode = false;
+                        refreshAllButtons();
+                        console.log('Tearoffs deleted');
+                    } else {
+                        handleBtnAction(spec, btnKey, true, spec.type === 'menu' ? buttonClone : undefined);
+                    }
+                }
+            });
+
+            // Context menu prevention
+            buttonClone.addEventListener('contextmenu', (e) => e.preventDefault());
+        }
+
+        container.appendChild(buttonClone);
+    }
+
+    // Add middle-click handler to delete tearoff when delete mode is active (BEFORE Leaflet event disabling)
+    container.addEventListener('mousedown', (e) => {
+        if (e.button === 1) {  // middle click
+            e.preventDefault();
+            e.stopPropagation();
+            if (tearoffDeleteMode) {
+                // Delete the middle-clicked tearoff plus all selected ones
+                selectedTearoffsForDeletion.add(btnKey);
+
+                for (const key of selectedTearoffsForDeletion) {
+                    const tearoff = activeTearoffs.get(key);
+                    if (tearoff) {
+                        tearoff.floatingEl.remove();
+                        activeTearoffs.delete(key);
+                    }
+                }
+
+                selectedTearoffsForDeletion.clear();
+                updateTearoffColors();
+                // Turn off delete mode after deleting
+                tearoffDeleteMode = false;
+                refreshAllButtons();
+                console.log('Tearoffs deleted');
+            }
+        }
+    });
+
+    // Add to page
+    document.body.appendChild(container);
+
+    // Prevent Leaflet from capturing events
+    L.DomEvent.disableClickPropagation(container);
+    L.DomEvent.disableScrollPropagation(container);
+
+    // Setup dragging via the tearoff strip (use standard setupBoxDrag)
+    const tearStrip = container.querySelector('.tb-tear');
+    setupBoxDrag(container, tearStrip);
+
+    // Position at the source button's location
+    const sourceBtn = sourceEntry?.el;
+    if (sourceBtn) {
+        const rect = sourceBtn.getBoundingClientRect();
+        container.style.left = rect.left + 'px';
+        container.style.top = rect.top + 'px';
+    } else {
+        // Fallback position
+        container.style.left = '100px';
+        container.style.top = '100px';
+    }
+
+    // Start drag mode immediately after creation
+    setTimeout(() => {
+        const tearStrip = container.querySelector('.tb-tear');
+        if (tearStrip && document.elementFromPoint(tearStrip.getBoundingClientRect().left + 5, tearStrip.getBoundingClientRect().top + 5) === tearStrip) {
+            // Simulate mousedown on tearoff strip to start dragging
+            const event = new MouseEvent('mousedown', {
+                bubbles: true,
+                cancelable: true,
+                clientX: tearStrip.getBoundingClientRect().left + 5,
+                clientY: tearStrip.getBoundingClientRect().top + 5,
+            });
+            tearStrip.dispatchEvent(event);
+        }
+    }, 0);
+
+    return { container, buttonClone };
+}
+
+function setupTearoffDrag(tearEl, spec, btnKey) {
+    tearEl.addEventListener('mousedown', (e) => {
+        if (e.button !== 0) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Grey tearoff strip (disabled) is non-functional - don't create tearoffs when one already exists
+        if (tearEl.dataset.disabled === 'true') {
+            return;
+        }
+
+        // Create new floating tearoff (only if one doesn't exist)
+        if (!activeTearoffs.has(btnKey)) {
+            const result = createFloatingTearoff(btnKey, spec);
+            activeTearoffs.set(btnKey, { floatingEl: result.container, buttonClone: result.buttonClone });
+            updateTearoffColors();
+
+            // Apply current backlight brightness to the new tearoff immediately
+            const l = scopeBcklght / 100;
+            const backlightFactor = 0.6 + (l * 0.5);
+            result.container.style.filter = `brightness(${backlightFactor})`;
+        }
+    });
+}
+
+function updateFloatingMenuButton(clickedEl, spec) {
+    // Find which floating menu this button is in (if any)
+    const isInToolbarMenu = (subMenuContainerEl && subMenuContainerEl.contains(clickedEl)) ||
+                            (subSubMenuContainerEl && subSubMenuContainerEl.contains(clickedEl));
+    const floatingMenuEl = clickedEl.closest('.tb-floating-menu');
+    const isInFloatingMenu = !!floatingMenuEl;
+
+    // If button was clicked in toolbar menu, update corresponding button in floating menu
+    if (isInToolbarMenu) {
+        const floatingMenus = document.querySelectorAll('.tb-floating-menu');
+        for (const floatingMenu of floatingMenus) {
+            const buttons = floatingMenu.querySelectorAll('.tb-btn');
+            const clickedRow = clickedEl.closest('.tb-row');
+            const rowIndex = Array.from(clickedRow.parentElement.children).indexOf(clickedRow);
+            const colIndex = Array.from(clickedRow.children).indexOf(clickedEl);
+
+            // For nested submenus, subtract 1 from rowIndex to account for parent button row in toolbar
+            const isNestedSubmenu = subSubMenuContainerEl && subSubMenuContainerEl.contains(clickedEl);
+            const adjustedRowIndex = isNestedSubmenu ? Math.max(0, rowIndex - 1) : rowIndex;
+            const clickedBtnPosition = adjustedRowIndex * 10 + colIndex;
+
+            if (buttons[clickedBtnPosition]) {
+                const correspondingBtn = buttons[clickedBtnPosition];
+                if (spec.type === 'toggle' && spec.isOn) {
+                    const shouldBeOn = spec.isOn();
+                    correspondingBtn.classList.toggle('tb-toggle-on', shouldBeOn);
+                } else if (spec.type === 'incdec' && spec.getValue) {
+                    const valDiv = correspondingBtn.querySelector('.tb-value');
+                    if (valDiv) {
+                        valDiv.textContent = spec.formatValue(spec.getValue());
+                    }
+                }
+            }
+        }
+    }
+    // If button was clicked in floating menu, update corresponding button in toolbar menu
+    else if (isInFloatingMenu) {
+        // Get position of clicked button
+        const buttons = floatingMenuEl.querySelectorAll('.tb-btn');
+        const clickedBtnIndex = Array.from(buttons).indexOf(clickedEl);
+
+        // Find corresponding toolbar menu container and button
+        let toolbarMenuContainer = null;
+        if (subMenuContainerEl && subMenuContainerEl.style.display !== 'none') {
+            toolbarMenuContainer = subMenuContainerEl;
+        } else if (subSubMenuContainerEl && subSubMenuContainerEl.style.display !== 'none') {
+            toolbarMenuContainer = subSubMenuContainerEl;
+        }
+
+        if (toolbarMenuContainer) {
+            const toolbarButtons = toolbarMenuContainer.querySelectorAll('.tb-btn');
+            if (toolbarButtons[clickedBtnIndex]) {
+                const correspondingBtn = toolbarButtons[clickedBtnIndex];
+                if (spec.type === 'toggle' && spec.isOn) {
+                    const shouldBeOn = spec.isOn();
+                    correspondingBtn.classList.toggle('tb-toggle-on', shouldBeOn);
+                } else if (spec.type === 'incdec' && spec.getValue) {
+                    const valDiv = correspondingBtn.querySelector('.tb-value');
+                    if (valDiv) {
+                        valDiv.textContent = spec.formatValue(spec.getValue());
+                    }
+                }
+            }
+        }
+    }
+}
+
 function createButton(spec, panelId, rowIdx, colIdx) {
     const el = document.createElement('div');
     el.className = 'tb-btn';
@@ -6827,6 +7121,9 @@ function createButton(spec, panelId, rowIdx, colIdx) {
     // Store reference (include valDiv for incdec buttons to avoid query overhead)
     tbElements.set(key, { el, spec, valDiv });
 
+    // Setup tearoff drag for the strip
+    setupTearoffDrag(tear, spec, key);
+
     // Event handling
     if (!isNosim) {
         // Left click
@@ -6834,7 +7131,24 @@ function createButton(spec, panelId, rowIdx, colIdx) {
             e.stopPropagation();
             // Ignore clicks on the tearoff strip
             if (!e.target.closest('.tb-tear')) {
-                handleBtnAction(spec, key, false);
+                // For menu buttons in floating menus, pass the button element as anchor
+                const isInFloatingMenu = el.closest('.tb-floating-menu');
+                const anchorForMenu = (spec.type === 'menu' && isInFloatingMenu) ? el : undefined;
+                handleBtnAction(spec, key, false, anchorForMenu);
+                // Update this button's visual state immediately (for menu buttons and floating menu buttons)
+                if (spec.type === 'toggle' && spec.isOn) {
+                    const shouldBeOn = spec.isOn();
+                    el.classList.toggle('tb-toggle-on', shouldBeOn);
+                    // Also update floating menu button if in a floating menu
+                    updateFloatingMenuButton(el, spec);
+                } else if (spec.type === 'incdec' && spec.getValue) {
+                    const valDiv = el.querySelector('.tb-value');
+                    if (valDiv) {
+                        valDiv.textContent = spec.formatValue(spec.getValue());
+                    }
+                    // Also update floating menu button if in a floating menu
+                    updateFloatingMenuButton(el, spec);
+                }
             }
         });
 
@@ -6846,6 +7160,15 @@ function createButton(spec, panelId, rowIdx, colIdx) {
                 // Ignore middle-clicks on the tearoff strip
                 if (!e.target.closest('.tb-tear')) {
                     handleBtnAction(spec, key, true);
+                    // Update this button's visual state immediately
+                    if (spec.type === 'incdec' && spec.getValue) {
+                        const valDiv = el.querySelector('.tb-value');
+                        if (valDiv) {
+                            valDiv.textContent = spec.formatValue(spec.getValue());
+                        }
+                        // Also update floating menu button if in a floating menu
+                        updateFloatingMenuButton(el, spec);
+                    }
                 }
             }
         });
@@ -6909,6 +7232,47 @@ function refreshButton(key) {
     if (spec.type === 'menu') {
         const isOpen = tbState.openMenu === spec.menu || tbState.openSubMenu === spec.menu;
         el.classList.toggle('tb-menu-open', isOpen);
+    }
+
+    // Sync floating tearoff button clone if one exists
+    const tearoff = activeTearoffs.get(key);
+    if (tearoff && tearoff.buttonClone) {
+        // Update clone's value display
+        const cloneValDiv = tearoff.buttonClone.querySelector('.tb-value');
+        if (cloneValDiv && spec.getValue) {
+            const newValue = String(spec.formatValue(spec.getValue()));
+            cloneValDiv.textContent = newValue;
+        }
+
+        // Update clone's toggle state (match original button exactly)
+        if (spec.type === 'toggle' && !isNosim && spec.isOn) {
+            const shouldBeOn = spec.isOn();
+            if (shouldBeOn) {
+                tearoff.buttonClone.classList.add('tb-toggle-on');
+            } else {
+                tearoff.buttonClone.classList.remove('tb-toggle-on');
+            }
+        }
+
+        // Don't sync menu-open state to floating tearoff buttons — they remain independent
+    }
+
+    // Handle DELETE TEAROFF button styling when in delete mode
+    if (spec.label && spec.label.includes('DELETE')) {
+        if (tearoffDeleteMode) {
+            el.classList.add('tb-menu-open');
+        } else {
+            el.classList.remove('tb-menu-open');
+        }
+        // Sync to floating tearoff if one exists
+        const tearoff = activeTearoffs.get(key);
+        if (tearoff && tearoff.buttonClone) {
+            if (tearoffDeleteMode) {
+                tearoff.buttonClone.classList.add('tb-menu-open');
+            } else {
+                tearoff.buttonClone.classList.remove('tb-menu-open');
+            }
+        }
     }
 }
 
@@ -6986,6 +7350,121 @@ function closeAllSubMenus() {
         });
     }
     refreshAllButtons();
+}
+
+function openFloatingMenu(menuId, anchorEl) {
+    const menuSpec = SUB_MENUS[menuId];
+    if (!menuSpec) return;
+
+    // Get the button key from the anchor element
+    const btnKey = anchorEl.dataset.tbKey;
+
+    // Check if menu already open for this button — close it (toggle)
+    if (activeFloatingMenus.has(btnKey)) {
+        const existing = activeFloatingMenus.get(btnKey);
+        if (existing.floatingMenuEl) {
+            existing.floatingMenuEl.remove();
+        }
+        // Remove menu-open class from the button
+        anchorEl.classList.remove('tb-menu-open');
+        activeFloatingMenus.delete(btnKey);
+        return;
+    }
+
+    // Create floating menu container
+    const floatingMenu = document.createElement('div');
+    floatingMenu.className = 'tb-floating-menu';
+
+    // Check if this is a nested menu (parent menu is already floating)
+    const parentFloatingMenu = anchorEl.closest('.tb-floating-menu');
+    const isNestedMenu = !!parentFloatingMenu;
+
+    if (isNestedMenu) {
+        // Nested menu: position absolutely relative to viewport
+        const anchorRect = anchorEl.getBoundingClientRect();
+        floatingMenu.style.cssText = `
+            position: fixed;
+            left: ${anchorRect.right + 4}px;
+            top: ${anchorRect.top}px;
+            z-index: 972;
+            user-select: none;
+            background: #0000D4;
+            border: 1px solid #FFFFFF;
+        `;
+    } else {
+        // Top-level floating menu: position relative to parent container
+        floatingMenu.style.cssText = `
+            position: absolute;
+            top: 0;
+            left: 100%;
+            margin-left: 4px;
+            z-index: 971;
+            user-select: none;
+            background: #0000D4;
+            border: 1px solid #FFFFFF;
+        `;
+    }
+
+    // Build menu items into the floating container (don't force 2 rows for floating menus)
+    buildSubMenuItems(menuSpec, menuId, floatingMenu, 0, false);
+
+    // Append to the floating tearoff container so it moves with the button (for top-level menus)
+    // or to the body (for nested menus that need fixed positioning)
+    if (isNestedMenu) {
+        document.body.appendChild(floatingMenu);
+    } else {
+        const floatingTearoff = anchorEl.closest('.tb-floating-tearoff');
+        if (floatingTearoff) {
+            floatingTearoff.appendChild(floatingMenu);
+        } else {
+            // Fallback: append to body if not in a floating tearoff (shouldn't happen)
+            document.body.appendChild(floatingMenu);
+        }
+    }
+
+    // Apply current backlight brightness to the floating menu
+    const l = scopeBcklght / 100;
+    const backlightFactor = 0.6 + (l * 0.5);
+    floatingMenu.style.filter = `brightness(${backlightFactor})`;
+
+    // Add menu-open class to the button for visual feedback
+    anchorEl.classList.add('tb-menu-open');
+
+    // Store in active menus map
+    activeFloatingMenus.set(btnKey, { floatingMenuEl: floatingMenu, anchorEl: anchorEl });
+
+    // Prevent Leaflet from capturing events
+    L.DomEvent.disableClickPropagation(floatingMenu);
+    L.DomEvent.disableScrollPropagation(floatingMenu);
+
+    // Close menu when clicking outside (but not on the anchor button itself, toolbar buttons, or inside toolbar menus)
+    const closeHandler = (e) => {
+        // Check if click is on a toolbar menu button or inside a toolbar menu container
+        const clickedBtn = e.target.closest('.tb-btn');
+        const isToolbarBtn = clickedBtn && tbElements.has(clickedBtn.dataset.tbKey);
+        const isInsideToolbarMenu = (subMenuContainerEl && subMenuContainerEl.contains(e.target)) ||
+                                     (subSubMenuContainerEl && subSubMenuContainerEl.contains(e.target));
+
+        if (!floatingMenu.contains(e.target) && !anchorEl.contains(e.target) && !isToolbarBtn && !isInsideToolbarMenu) {
+            floatingMenu.remove();
+            anchorEl.classList.remove('tb-menu-open');
+            activeFloatingMenus.delete(btnKey);
+            document.removeEventListener('mousedown', closeHandler);
+        }
+    };
+    document.addEventListener('mousedown', closeHandler);
+
+    // Close menu when an item is clicked
+    floatingMenu.addEventListener('click', (e) => {
+        if (e.target.closest('.tb-btn')) {
+            setTimeout(() => {
+                floatingMenu.remove();
+                anchorEl.classList.remove('tb-menu-open');
+                activeFloatingMenus.delete(btnKey);
+            }, 10);
+            document.removeEventListener('mousedown', closeHandler);
+        }
+    });
 }
 
 function openSubMenu(menuId, anchorEl) {
@@ -7074,10 +7553,11 @@ const MENU_LABELS = {
 
 // Build sub-menu items only (no parent button — the real one stays in the master panel).
 // parentRow = which visual row the parent is on. Data row 0 goes on parentRow, row 1 on parentRow+1, etc.
-function buildSubMenuItems(menuSpec, menuId, container, parentRow) {
+// forceMinRows = if true, render at least 2 rows (for toolbar); if false, render only needed rows (for floating menus)
+function buildSubMenuItems(menuSpec, menuId, container, parentRow, forceMinRows = true) {
     if (parentRow === undefined) parentRow = 0;
-    // Always render exactly 2 rows, data rows start at row 0 (top)
-    const totalRows = 2;
+    // For toolbar menus, always render at least 2 rows. For floating menus, render only what's needed.
+    const totalRows = forceMinRows ? Math.max(2, menuSpec.rows.length) : menuSpec.rows.length;
 
     for (let vi = 0; vi < totalRows; vi++) {
         const rowEl = document.createElement('div');
@@ -7123,10 +7603,19 @@ function buildInlineSubMenu(menuSpec, menuId, container, parentRow) {
     }
 }
 
-function handleBtnAction(spec, key, isMiddle) {
+function handleBtnAction(spec, key, isMiddle, anchorEl) {
     if (spec.type === 'menu') {
-        const entry = tbElements.get(key);
-        openSubMenu(spec.menu, entry.el);
+        // If anchorEl is provided (from floating tearoff), create a floating menu
+        if (anchorEl && anchorEl.closest('.tb-floating-tearoff')) {
+            openFloatingMenu(spec.menu, anchorEl);
+        } else if (anchorEl && anchorEl.closest('.tb-floating-menu')) {
+            // Menu button clicked in a floating menu - open nested menu as floating
+            openFloatingMenu(spec.menu, anchorEl);
+        } else {
+            // Otherwise, use toolbar menu system
+            const anchor = anchorEl || tbElements.get(key)?.el;
+            if (anchor) openSubMenu(spec.menu, anchor);
+        }
     } else if (spec.type === 'toggle') {
         if (spec.isOn && spec.onToggle) {
             spec.onToggle(!spec.isOn());
@@ -7269,6 +7758,7 @@ if (_tbInitParams.get('tb') !== '0') {
 // ── Initialize ──
 buildToolbar();
 refreshAllButtons();  // Refresh button displays to show correct initial values
+updateTearoffColors();  // Initialize tearoff strip colors
 updateBorderBrightness();  // Initialize border brightness
 updateToolbarBackgroundBrightness();  // Initialize toolbar background brightness
 updateTextBrightness();  // Initialize text brightness

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -2742,6 +2742,31 @@ document.getElementById('chk-mca-kb').addEventListener('change', function () {
     saveSettingsToLocalStorage();
 });
 
+const chkMca = document.getElementById('chk-mca');
+const chkRa = document.getElementById('chk-ra');
+const chkTime = document.getElementById('chk-time');
+if (chkMca) {
+    chkMca.addEventListener('change', function () {
+        const mca = document.getElementById('mca');
+        if (mca) mca.style.display = this.checked ? 'block' : 'none';
+        saveSettingsToLocalStorage();
+    });
+}
+if (chkRa) {
+    chkRa.addEventListener('change', function () {
+        const ra = document.getElementById('ra');
+        if (ra) ra.style.display = this.checked ? 'block' : 'none';
+        saveSettingsToLocalStorage();
+    });
+}
+if (chkTime) {
+    chkTime.addEventListener('change', function () {
+        const timeView = document.getElementById('time-view');
+        if (timeView) timeView.style.display = this.checked ? 'block' : 'none';
+        saveSettingsToLocalStorage();
+    });
+}
+
 // Transp MCA: reserved for future use
 // document.getElementById('chk-transp-mca').addEventListener('change', function () {
 //     document.getElementById('map-container').classList.toggle('transp-mca', this.checked);
@@ -3683,6 +3708,9 @@ function saveSettingsToLocalStorage() {
         ldbBrightness,
         facilityOnly,
         mcaKb: document.getElementById('chk-mca-kb')?.checked || false,
+        mcaVisible: document.getElementById('chk-mca')?.checked !== false,
+        raVisible: document.getElementById('chk-ra')?.checked !== false,
+        timeVisible: document.getElementById('chk-time')?.checked !== false,
         numinv: !document.getElementById('numpad-inverted')?.checked,
         nasrBrightness,
         nexradLevel,

--- a/tools/SwimServer/wwwroot/eram/eram.js
+++ b/tools/SwimServer/wwwroot/eram/eram.js
@@ -24,6 +24,7 @@ let altFilterLow = 0;      // FL (hundreds of feet), 0 = no filter
 let altFilterHigh = 999;    // FL (hundreds of feet), 999 = no filter
 let fontSize = 10;          // data block font size in px
 let ldbBrightness = 30;     // 0-100, opacity for LDB data blocks (0=hidden, 100=same as FDB)
+let showPortalFence = true; // two corner brackets on FDB with PO/R indicators
 let showMapBg = false;      // tile layer hidden by default
 let line4Mode = 'DEST';     // 'DEST' | 'TYPE' | 'OFF' — what FDB line 4 shows
 const quickLookSectors = new Set(); // QL sectors — force FDB on tracks in these sectors without claiming ownership
@@ -1570,6 +1571,13 @@ function formatFdbHtml(f, cls) {
     html += `${showVci ? col0Vci : col0Hit}${l2}\n`;
     html += `${showR ? col0R : col0Sp}${l3}`;
     if (l4) html += `\n${col0Sp}${l4}`;
+    if (showPortalFence && (poInfo || showR)) {
+        const fenceColor = cls === 'emrg' ? '#ff4444' : '#d0d0d0';
+        // Use CSS ch/em units for sizing (matches actual font metrics) and SVG rendering for flicker-free strokes.
+        // top: 0 when no line 0; top: calc(1.25em + 1px) skips line 0 (1 line-height + ac-db top padding).
+        const topStyle = poInfo ? 'calc(1.25em + 3px)' : '2px';
+        html += `<svg style="position:absolute;top:${topStyle};left:calc(1.5ch + 1px);width:3ch;height:3.75em;overflow:visible;pointer-events:none;" viewBox="0 0 100 100" preserveAspectRatio="none"><polyline points="100,0.5 0.5,0.5 0.5,100" fill="none" stroke="${fenceColor}" stroke-width="1" vector-effect="non-scaling-stroke" stroke-linejoin="miter"/></svg>`;
+    }
     return html;
 }
 
@@ -2169,7 +2177,7 @@ function flightHash(f, cls) {
     const poAck = pointoutAcked.has(f.gufi) ? 1 : 0;
     const coast = isCoasting(f) ? 1 : 0;
     const ais = f._altInitialSide || 0;
-    return `${f.latitude}|${f.longitude}|${f.callsign}|${f.reportedAltitude}|${f.assignedAltitude}|${f.interimAltitude}|${f.assignedVfr||0}|${f.blockFloor||''}|${f.blockCeiling||''}|${f.squawk}|${f.assignedSquawk||''}|${f.handoffEvent}|${f.handoffReceiving}|${f.controllingFacility}|${f.controllingSector}|${f.groundSpeed}|${f.destination}|${getCid(f)}|${cls}|${useFdb}|${useFdb ? 0 : ldbBrightness}|${hoc}|${rInd}|${dbPos}|${ldrLen}|${vci}|${laH}|${liH}|${lrH}|${line4Mode}|${f.aircraftType||''}|${hsfH}|${hsfS}|${f.clearanceHeading||''}|${f.clearanceSpeed||''}|${f.clearanceText||''}|${poAck}|${f.pointoutOriginatingUnit||''}|${f.pointoutReceivingUnit||''}|${coast}|${f.flightStatus||''}|${ais}`;
+    return `${f.latitude}|${f.longitude}|${f.callsign}|${f.reportedAltitude}|${f.assignedAltitude}|${f.interimAltitude}|${f.assignedVfr||0}|${f.blockFloor||''}|${f.blockCeiling||''}|${f.squawk}|${f.assignedSquawk||''}|${f.handoffEvent}|${f.handoffReceiving}|${f.controllingFacility}|${f.controllingSector}|${f.groundSpeed}|${f.destination}|${getCid(f)}|${cls}|${useFdb}|${useFdb ? 0 : ldbBrightness}|${hoc}|${rInd}|${dbPos}|${ldrLen}|${vci}|${laH}|${liH}|${lrH}|${line4Mode}|${f.aircraftType||''}|${hsfH}|${hsfS}|${f.clearanceHeading||''}|${f.clearanceSpeed||''}|${f.clearanceText||''}|${poAck}|${f.pointoutOriginatingUnit||''}|${f.pointoutReceivingUnit||''}|${coast}|${f.flightStatus||''}|${ais}|${showPortalFence?1:0}`;
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -6210,7 +6218,10 @@ const TB_DB_FIELDS = {
                 onInc: () => {},
             }),
             { label: 'BCAST\nFLID', type: 'toggle', nosim: true },
-            { label: 'PORTAL\nFENCE', type: 'toggle', nosim: true },
+            toggle('PORTAL\nFENCE', {
+                isOn: () => showPortalFence,
+                onToggle: (on) => { showPortalFence = on; invalidateAllMarkers(); },
+            }),
         ],
         [
             nosim('NON-\nADS-B'),

--- a/tools/SwimServer/wwwroot/eram/index.html
+++ b/tools/SwimServer/wwwroot/eram/index.html
@@ -134,6 +134,11 @@
                 <label><input type="checkbox" id="chk-mapbg"> Map Bg</label>
                 <label style="margin-left:12px;"><input type="checkbox" id="chk-mca-kb"> KB</label>
             </div>
+            <div class="ctrl-row">
+                <label><input type="checkbox" id="chk-mca" checked> MCA</label>
+                <label style="margin-left:12px;"><input type="checkbox" id="chk-ra" checked> RA</label>
+                <label style="margin-left:12px;"><input type="checkbox" id="chk-time" checked> Time</label>
+            </div>
             <!-- Transp MCA: reserved for future use
             <div class="ctrl-row">
                 <label><input type="checkbox" id="chk-transp-mca"> Transp MCA</label>


### PR DESCRIPTION
Added ERAM brightness functionality
- DCB now matches real world color scheme accurately.
- Scope background now fades from ERAM blue to black.
- The following brightness sliders now are functional with accurate colors: BCKLGHT (adjusts the whole screen brightness down to 60% min), BUTTON, BCKGRD, BORDER, TOOLBAR, TEXT

Improved DCB UI and added functionality
- DCB buttons now properly match real world colors.
- Removed the disabled effect look from buttons. If there is no functionality at the moment it just appears normal but will not click.
- Added a border on hover of each button/tearoff.
- Separated tearoff and button functionality.
- Added cursor and toolbar brightness slider functionality.

Added button tearoff functionality
- Tearoff strips for each button now work, allowing you to drag a duplicated fully working version of a button onto the radar.
- Tearoffs work independently of the DCB but colors will sync.
- Tearoffs for menus will open separate popup menus in the scope.
- Tearoffs can be deleted using the delete tearoff button and then middle clicking a single target or marking multiple targets with a left click before middle clicking.

Add scrollbar to submenus
- Submenus that are larger than the user's screen can now scroll horizontally.

Added portal fences
- Portal fences are now drawn by default for planes with data in column 0 or row 0. These can be manually turned off within DB fields

Amended local storage to accept brightness
- Local storage now tracks settings for brightness and color as well as position and sector information to start a user from their most recent state.
- Major performance improvement over using URL storage.

Fix toolbar brightness main screen
- Main screen now also gets the color set by the toolbar brightness bar. Additionally, the dropdown arrow on the left of the DCB takes the color.
- Scroll functions were fixed to now work within second submenus.

Fixed bug that would shrink dcb on tab refocus
- When you would switch tabs in the browser, the DCB would be clamped down to a smaller size. This was fixed by removing a clampBox function.

Added CODE/SPEED toggle buttons
- Added momentary toggles to quickly see the code or speed of an aircraft in the data block by holding down these buttons.
